### PR TITLE
Fix runtime crash from directional light shadow configuration

### DIFF
--- a/src/pages/ChessGame.tsx
+++ b/src/pages/ChessGame.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, PerspectiveCamera, Environment } from "@react-three/drei";
+import type { DirectionalLight } from "three";
 import { FbxChessSet } from "@/components/FbxChessSet";
 import { Chess } from "chess.js";
 import { Button } from "@/components/ui/button";
@@ -344,7 +345,9 @@ export default function ChessGame() {
                     position={[10, 10, 5]}
                     intensity={1}
                     castShadow
-                    shadow-mapSize={[2048, 2048]}
+                    onUpdate={(light: DirectionalLight) => {
+                      light.shadow.mapSize.set(2048, 2048);
+                    }}
                   />
                   <FbxChessSet />
                   <ChessBoard3D


### PR DESCRIPTION
## Summary
- replace the deprecated shadow-mapSize prop on the game scene's directional light with an explicit onUpdate handler
- type the light update callback to ensure proper shadow map configuration without runtime errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc292dea8c832391463803e22c2a0a