### PR TITLE
Handle tailwind-merge runtime failures

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,5 +2,18 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  const className = clsx(inputs);
+
+  try {
+    return twMerge(className);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("tailwind-merge failed to process class names", {
+        className,
+        error
+      });
+    }
+
+    return className;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap the shared `cn` helper with error handling so tailwind-merge failures fall back to plain class names
- log a development warning when tailwind-merge cannot process a class list to aid future debugging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2aaf7a2c83239fe0dc1c3db7f2fb