### PR TITLE
Handle data attributes in FbxChessSet to prevent runtime crash

### DIFF
--- a/src/components/FbxChessSet.tsx
+++ b/src/components/FbxChessSet.tsx
@@ -1,7 +1,16 @@
 import { useMemo } from 'react';
-import { BoxGeometry, MeshLambertMaterial, Mesh } from 'three';
 
-export function FbxChessSet(props: JSX.IntrinsicElements['group']) {
+type GroupProps = JSX.IntrinsicElements['group'];
+
+function filterThreeProps(props: GroupProps): GroupProps {
+  const filteredEntries = Object.entries(props).filter(([key]) => {
+    return !key.startsWith('data-') && !key.startsWith('aria-');
+  });
+
+  return Object.fromEntries(filteredEntries) as GroupProps;
+}
+
+export function FbxChessSet({ children, ...rest }: GroupProps) {
   // Create a simple decorative table/platform for the chess board
   const platform = useMemo(() => {
     return (
@@ -39,5 +48,12 @@ export function FbxChessSet(props: JSX.IntrinsicElements['group']) {
     );
   }, []);
 
-  return <group {...props}>{platform}</group>;
+  const groupProps = useMemo(() => filterThreeProps(rest), [rest]);
+
+  return (
+    <group {...groupProps}>
+      {platform}
+      {children}
+    </group>
+  );
 }


### PR DESCRIPTION
## Summary
- filter out `data-*` and `aria-*` attributes before forwarding props to the `<group>` rendered by `FbxChessSet`
- keep existing platform rendering while allowing children to pass through the wrapper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc43e56a3083238c11c0181b9613cb