### PR TITLE
Add multiplayer lobby and switch coaching AI to Groq

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 **URL**: https://lovable.dev/projects/6a8b1507-b5c3-4213-9ae4-7a9d9899ff6f
 
+## Nouveautés
+
+- Lobby multijoueur permettant de créer ou rejoindre des salons en temps réel.
+- Analyse IA reposant sur le modèle open source **Llama 3 8B** via l'API Groq.
+
+### Configuration requise
+
+Définissez la variable d'environnement suivante pour Supabase Edge Functions :
+
+```
+GROQ_API_KEY=<votre_clef_api_groq>
+```
+
+Cette clé est utilisée par la fonction `chess-coach` pour générer les conseils via le modèle open source.
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ChessHome from "./pages/ChessHome";
 import ChessGame from "./pages/ChessGame";
+import Lobby from "./pages/Lobby";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -17,6 +18,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<ChessHome />} />
+          <Route path="/lobby" element={<Lobby />} />
           <Route path="/game" element={<ChessGame />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,7 +14,45 @@ export type Database = {
   }
   public: {
     Tables: {
-      [_ in never]: never
+      chess_lobbies: {
+        Row: {
+          coaching_mode: boolean
+          created_at: string
+          elo_level: string | null
+          id: string
+          increment: number
+          minutes: number
+          host_name: string
+          opponent_name: string | null
+          status: string
+          time_control: string
+        }
+        Insert: {
+          coaching_mode?: boolean
+          created_at?: string
+          elo_level?: string | null
+          id?: string
+          increment?: number
+          minutes: number
+          host_name: string
+          opponent_name?: string | null
+          status?: string
+          time_control: string
+        }
+        Update: {
+          coaching_mode?: boolean
+          created_at?: string
+          elo_level?: string | null
+          id?: string
+          increment?: number
+          minutes?: number
+          host_name?: string
+          opponent_name?: string | null
+          status?: string
+          time_control?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/pages/ChessHome.tsx
+++ b/src/pages/ChessHome.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Clock, Zap, Brain, Trophy } from "lucide-react";
+import { Clock, Zap, Brain, Trophy, Users } from "lucide-react";
 import { CustomRulesGenerator } from "@/components/CustomRulesGenerator";
 
 const timeControls = [
@@ -67,6 +67,17 @@ export default function ChessHome() {
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
             Maîtrisez l'art des échecs dans un environnement 3D immersif avec intelligence artificielle avancée
           </p>
+          <div className="flex justify-center gap-4 mt-6">
+            <Button
+              variant="outline"
+              size="lg"
+              className="hover-lift"
+              onClick={() => navigate("/lobby")}
+            >
+              <Users className="w-5 h-5 mr-2" />
+              Ouvrir le lobby multijoueur
+            </Button>
+          </div>
         </div>
 
         <div className="max-w-6xl mx-auto grid lg:grid-cols-2 gap-8">

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { Clock, Users, Sword, Hourglass, PlusCircle, XCircle } from "lucide-react";
+
+const timeControls = [
+  { id: "1+0", label: "Bullet 1+0", minutes: 1, increment: 0 },
+  { id: "2+1", label: "Bullet 2+1", minutes: 2, increment: 1 },
+  { id: "3+0", label: "Blitz 3+0", minutes: 3, increment: 0 },
+  { id: "5+0", label: "Blitz 5+0", minutes: 5, increment: 0 },
+  { id: "10+0", label: "Rapid 10+0", minutes: 10, increment: 0 },
+  { id: "15+10", label: "Rapid 15+10", minutes: 15, increment: 10 },
+  { id: "30+0", label: "Classique 30+0", minutes: 30, increment: 0 },
+];
+
+const eloLevels = [
+  { id: "beginner", label: "Débutant (800-1200)" },
+  { id: "intermediate", label: "Amateur (1200-1600)" },
+  { id: "advanced", label: "Confirmé (1600-2000)" },
+  { id: "expert", label: "Expert (2000-2400)" },
+  { id: "master", label: "Maître (2400+)" },
+];
+
+type LobbyRow = {
+  id: string;
+  host_name: string;
+  time_control: string;
+  minutes: number;
+  increment: number;
+  elo_level: string | null;
+  coaching_mode: boolean;
+  status: string;
+  opponent_name: string | null;
+  created_at: string;
+};
+
+export default function Lobby() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [hostName, setHostName] = useState("");
+  const [selectedTime, setSelectedTime] = useState(timeControls[2].id);
+  const [selectedElo, setSelectedElo] = useState(eloLevels[1].id);
+  const [coachingMode, setCoachingMode] = useState(false);
+
+  const selectedTimeConfig = useMemo(
+    () => timeControls.find((control) => control.id === selectedTime) ?? timeControls[0],
+    [selectedTime]
+  );
+  const selectedEloConfig = useMemo(
+    () => eloLevels.find((level) => level.id === selectedElo) ?? eloLevels[0],
+    [selectedElo]
+  );
+
+  const lobbyQuery = useQuery({
+    queryKey: ["chess-lobbies"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("chess_lobbies")
+        .select("*")
+        .in("status", ["open", "matched"])
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        throw error;
+      }
+
+      return data as LobbyRow[];
+    },
+  });
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("chess-lobby-updates")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "chess_lobbies" },
+        () => {
+          queryClient.invalidateQueries({ queryKey: ["chess-lobbies"] });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [queryClient]);
+
+  const createLobbyMutation = useMutation({
+    mutationFn: async () => {
+      if (!hostName.trim()) {
+        throw new Error("Veuillez renseigner votre pseudonyme.");
+      }
+
+      const { error } = await supabase.from("chess_lobbies").insert({
+        host_name: hostName.trim(),
+        time_control: selectedTimeConfig.id,
+        minutes: selectedTimeConfig.minutes,
+        increment: selectedTimeConfig.increment,
+        elo_level: selectedEloConfig.label,
+        coaching_mode: coachingMode,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      toast.success("Salon créé ! Les autres joueurs peuvent vous rejoindre.");
+      setHostName("");
+      queryClient.invalidateQueries({ queryKey: ["chess-lobbies"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const joinLobby = async (lobby: LobbyRow) => {
+    const playerName = window.prompt("Entrez votre pseudonyme pour rejoindre ce salon :");
+    if (!playerName) {
+      return;
+    }
+
+    const timeConfig = timeControls.find((control) => control.id === lobby.time_control);
+    const timeLabel = timeConfig?.label ?? lobby.time_control;
+
+    const { error } = await supabase
+      .from("chess_lobbies")
+      .update({ status: "matched", opponent_name: playerName.trim() })
+      .eq("id", lobby.id);
+
+    if (error) {
+      toast.error("Impossible de rejoindre le salon.");
+      return;
+    }
+
+    toast.success("Salon rejoint ! Préparation de la partie...");
+
+    const levelLabel = lobby.elo_level ?? "Libre";
+
+    navigate("/game", {
+      state: {
+        timeControl: {
+          name: timeLabel,
+          time: lobby.time_control,
+          minutes: lobby.minutes,
+          increment: lobby.increment,
+          description: "Partie depuis le lobby",
+        },
+        eloLevel: { name: levelLabel, elo: levelLabel, color: "bg-blue-500" },
+        coachingMode: lobby.coaching_mode,
+        lobbyId: lobby.id,
+        hostName: lobby.host_name,
+        opponentName: playerName.trim(),
+      },
+    });
+  };
+
+  const closeLobby = async (lobby: LobbyRow) => {
+    const confirmClose = window.confirm("Voulez-vous fermer ce salon ?");
+    if (!confirmClose) {
+      return;
+    }
+
+    const { error } = await supabase
+      .from("chess_lobbies")
+      .update({ status: "closed" })
+      .eq("id", lobby.id);
+
+    if (error) {
+      toast.error("Impossible de fermer le salon.");
+      return;
+    }
+
+    toast.success("Salon fermé.");
+  };
+
+  return (
+    <div className="min-h-screen bg-background relative overflow-hidden">
+      <div className="absolute inset-0 gradient-board opacity-90" />
+      <div className="relative z-10 container mx-auto px-6 py-12 space-y-10">
+        <div className="flex items-center justify-between flex-col lg:flex-row gap-6">
+          <div className="space-y-2">
+            <Badge variant="outline" className="uppercase tracking-widest text-chess-gold">
+              Lobby multijoueur
+            </Badge>
+            <h1 className="text-4xl lg:text-5xl font-bold gradient-chess bg-clip-text text-transparent">
+              Rejoignez un salon d'échecs 3D
+            </h1>
+            <p className="text-muted-foreground max-w-2xl">
+              Créez un salon pour inviter un ami ou rejoignez une partie existante. Lorsque le salon est rempli, la partie se
+              lance automatiquement contre notre IA ou votre adversaire selon vos préférences.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => navigate("/")} className="hover-lift">
+            Retour à l'accueil
+          </Button>
+        </div>
+
+        <div className="grid lg:grid-cols-[420px,1fr] gap-8">
+          <Card className="p-6 gradient-card border-chess space-y-6">
+            <div className="space-y-1">
+              <h2 className="text-2xl font-semibold text-chess-gold flex items-center gap-2">
+                <PlusCircle className="w-5 h-5" />
+                Créer un salon
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Configurez le rythme de jeu et attendez que votre ami vous rejoigne.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="host-name">Votre pseudonyme</Label>
+                <Input
+                  id="host-name"
+                  placeholder="Capablanca42"
+                  value={hostName}
+                  onChange={(event) => setHostName(event.target.value)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Cadence</Label>
+                <Select value={selectedTime} onValueChange={setSelectedTime}>
+                  <SelectTrigger className="bg-background/80">
+                    <SelectValue placeholder="Choisissez une cadence" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {timeControls.map((control) => (
+                      <SelectItem key={control.id} value={control.id}>
+                        {control.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Niveau souhaité</Label>
+                <Select value={selectedElo} onValueChange={setSelectedElo}>
+                  <SelectTrigger className="bg-background/80">
+                    <SelectValue placeholder="Sélectionnez un niveau" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {eloLevels.map((level) => (
+                      <SelectItem key={level.id} value={level.id}>
+                        {level.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border border-border px-4 py-3 bg-background/60">
+                <div>
+                  <p className="font-medium">Mode coaching</p>
+                  <p className="text-xs text-muted-foreground">
+                    Activez pour obtenir des conseils IA pendant la partie.
+                  </p>
+                </div>
+                <Switch checked={coachingMode} onCheckedChange={setCoachingMode} />
+              </div>
+            </div>
+
+            <Button
+              className="w-full hover-lift"
+              variant="chess"
+              disabled={createLobbyMutation.isPending}
+              onClick={() => createLobbyMutation.mutate()}
+            >
+              {createLobbyMutation.isPending ? "Création..." : "Ouvrir le salon"}
+            </Button>
+          </Card>
+
+          <Card className="p-6 gradient-card border-chess">
+            <div className="flex items-center justify-between mb-6">
+              <div className="flex items-center gap-3">
+                <Users className="w-6 h-6 text-chess-gold" />
+                <h2 className="text-2xl font-semibold text-chess-gold">Salons disponibles</h2>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => lobbyQuery.refetch()} className="hover-lift">
+                Rafraîchir
+              </Button>
+            </div>
+
+            {lobbyQuery.isLoading ? (
+              <div className="space-y-4">
+                {[1, 2, 3].map((skeleton) => (
+                  <Skeleton key={skeleton} className="h-24 w-full bg-background/50" />
+                ))}
+              </div>
+            ) : lobbyQuery.isError ? (
+              <div className="p-6 text-center text-muted-foreground">
+                Impossible de charger les salons. Veuillez réessayer plus tard.
+              </div>
+            ) : lobbyQuery.data.length === 0 ? (
+              <div className="p-10 text-center text-muted-foreground bg-background/40 rounded-lg border border-border">
+                Aucun salon disponible pour le moment. Créez le vôtre pour inviter d'autres joueurs !
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {lobbyQuery.data.map((lobby) => (
+                  <div
+                    key={lobby.id}
+                    className="p-5 rounded-xl border border-border bg-background/60 hover:bg-background/80 transition-colors"
+                  >
+                    <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Clock className="w-4 h-4" />
+                          {new Intl.DateTimeFormat("fr-FR", {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          }).format(new Date(lobby.created_at))}
+                        </div>
+                        <h3 className="text-xl font-semibold text-chess-gold">
+                          {lobby.host_name} cherche un adversaire
+                        </h3>
+                        <div className="flex flex-wrap items-center gap-2 text-sm">
+                          <Badge variant="outline" className="flex items-center gap-1">
+                            <Hourglass className="w-3 h-3" />
+                            {lobby.time_control}
+                          </Badge>
+                          {lobby.elo_level && (
+                            <Badge variant="secondary">{lobby.elo_level}</Badge>
+                          )}
+                          {lobby.coaching_mode && (
+                            <Badge variant="default" className="bg-accent text-background">
+                              Coaching IA
+                            </Badge>
+                          )}
+                          {lobby.status === "matched" && lobby.opponent_name && (
+                            <Badge variant="default" className="bg-primary text-background">
+                              {lobby.opponent_name} a rejoint
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        {lobby.status === "open" && (
+                          <Button className="hover-lift" onClick={() => joinLobby(lobby)}>
+                            <Sword className="w-4 h-4 mr-2" />
+                            Rejoindre
+                          </Button>
+                        )}
+                        <Button
+                          variant="outline"
+                          className="hover-lift"
+                          onClick={() => closeLobby(lobby)}
+                        >
+                          <XCircle className="w-4 h-4 mr-2" />
+                          Fermer
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/supabase/functions/chess-coach/index.ts
+++ b/supabase/functions/chess-coach/index.ts
@@ -20,9 +20,9 @@ serve(async (req) => {
   }
 
   try {
-    const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
-    if (!openAIApiKey) {
-      throw new Error('OPENAI_API_KEY is not set');
+    const groqApiKey = Deno.env.get('GROQ_API_KEY');
+    if (!groqApiKey) {
+      throw new Error('GROQ_API_KEY is not set');
     }
 
     const { position, lastMove, gamePhase = 'opening', moveCount = 1 }: ChessCoachRequest = await req.json();
@@ -66,14 +66,14 @@ Analyse brièvement la position et donne un conseil constructif.`;
 - Opposition et zugzwang`;
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${openAIApiKey}`,
+        'Authorization': `Bearer ${groqApiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: 'llama3-8b-8192',
         messages: [
           { 
             role: 'system', 
@@ -93,8 +93,8 @@ Analyse brièvement la position et donne un conseil constructif.`;
 
     if (!response.ok) {
       const errorData = await response.text();
-      console.error('OpenAI API error:', errorData);
-      throw new Error(`OpenAI API error: ${response.status}`);
+      console.error('Groq API error:', errorData);
+      throw new Error(`Groq API error: ${response.status}`);
     }
 
     const data = await response.json();

--- a/supabase/migrations/20250217000000_add_chess_lobbies.sql
+++ b/supabase/migrations/20250217000000_add_chess_lobbies.sql
@@ -1,0 +1,27 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.chess_lobbies (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  host_name text not null,
+  time_control text not null,
+  minutes integer not null,
+  increment integer not null default 0,
+  elo_level text,
+  coaching_mode boolean not null default false,
+  status text not null default 'open',
+  opponent_name text
+);
+
+alter table public.chess_lobbies enable row level security;
+
+create policy "Allow anonymous read" on public.chess_lobbies
+  for select using (true);
+
+create policy "Allow anonymous insert" on public.chess_lobbies
+  for insert with check (true);
+
+create policy "Allow anonymous update" on public.chess_lobbies
+  for update using (true) with check (true);
+
+create index if not exists chess_lobbies_status_idx on public.chess_lobbies (status);


### PR DESCRIPTION
## Summary
- add a lobby page that lists realtime Supabase salons and lets players create, join, or close rooms
- expose the new lobby route from the home page and document the Groq-powered coaching capability
- switch the chess-coach Edge Function to the open-source Llama 3 8B model and add the required database schema/types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc5189c0048323bb8a3863b97aa682