### PR TITLE
Add real-time chess coaching insights and natural speech

### DIFF
--- a/src/hooks/use-speech.ts
+++ b/src/hooks/use-speech.ts
@@ -1,25 +1,73 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-export function useSpeechSynthesis(text: string) {
+interface SpeechOptions {
+  voicePreferences?: string[];
+  rate?: number;
+  pitch?: number;
+  volume?: number;
+}
+
+const DEFAULT_PREFERENCES = ["Google", "Amelie", "Thomas", "fr", "French"];
+
+export function useSpeechSynthesis(text: string, options: SpeechOptions = {}) {
+  const lastUtteranceRef = useRef<string>("");
+
   useEffect(() => {
-    if (!text || typeof window === "undefined") return;
-    if (!("speechSynthesis" in window)) return;
+    if (!text || !text.trim() || typeof window === "undefined") return;
 
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.lang = "fr-FR";
-    const voices = window.speechSynthesis.getVoices();
-    const frenchVoice = voices.find((v) => v.lang.startsWith("fr"));
-    if (frenchVoice) {
-      utterance.voice = frenchVoice;
+    const synthesis = window.speechSynthesis;
+    if (!synthesis) return;
+
+    if (text === lastUtteranceRef.current) return;
+
+    const voicePreferences = options.voicePreferences?.length ? options.voicePreferences : DEFAULT_PREFERENCES;
+    const rate = options.rate ?? 0.98;
+    const pitch = options.pitch ?? 1;
+    const volume = options.volume ?? 1;
+
+    let cancelled = false;
+
+    const speakWithVoices = (voices: SpeechSynthesisVoice[]) => {
+      if (cancelled || !voices.length) return;
+
+      const normalizedPreferences = voicePreferences.map((pref) => pref.toLowerCase());
+      const preferredVoice =
+        voices.find((voice) => normalizedPreferences.some((pref) => voice.name.toLowerCase().includes(pref))) ||
+        voices.find((voice) => voice.lang.toLowerCase().startsWith("fr")) ||
+        voices[0];
+
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.voice = preferredVoice;
+      utterance.lang = preferredVoice?.lang ?? "fr-FR";
+      utterance.rate = rate;
+      utterance.pitch = pitch;
+      utterance.volume = volume;
+
+      synthesis.cancel();
+      lastUtteranceRef.current = text;
+      synthesis.speak(utterance);
+    };
+
+    const handleVoicesChanged = () => {
+      const voices = synthesis.getVoices();
+      if (voices.length) {
+        speakWithVoices(voices);
+      }
+    };
+
+    const existingVoices = synthesis.getVoices();
+    if (existingVoices.length) {
+      speakWithVoices(existingVoices);
+    } else {
+      synthesis.addEventListener("voiceschanged", handleVoicesChanged);
     }
 
-    window.speechSynthesis.cancel();
-    window.speechSynthesis.speak(utterance);
-
     return () => {
-      window.speechSynthesis.cancel();
+      cancelled = true;
+      synthesis.removeEventListener("voiceschanged", handleVoicesChanged);
+      synthesis.cancel();
     };
-  }, [text]);
+  }, [text, options.voicePreferences, options.rate, options.pitch, options.volume]);
 }
 
 export default useSpeechSynthesis;

--- a/src/lib/chessAnalysis.ts
+++ b/src/lib/chessAnalysis.ts
@@ -1,0 +1,380 @@
+import type { Chess, Move } from "chess.js";
+import { detectOpeningFromHistory, sanitizeSanMoves, type OpeningMatch } from "./openings";
+
+const PIECE_VALUES: Record<string, number> = {
+  p: 1,
+  n: 3.2,
+  b: 3.3,
+  r: 5.1,
+  q: 9.4,
+  k: 0,
+};
+
+const CENTER = new Set(["d4", "e4", "d5", "e5"]);
+const EXTENDED_CENTER = new Set(["c3", "c4", "c5", "c6", "d3", "d6", "e3", "e6", "f3", "f4", "f5", "f6"]);
+
+const PIECE_NAMES: Record<string, string> = {
+  p: "pion",
+  n: "cavalier",
+  b: "fou",
+  r: "tour",
+  q: "dame",
+  k: "roi",
+};
+
+const START_SQUARES: Record<'w' | 'b', Record<string, string[]>> = {
+  w: {
+    n: ["b1", "g1"],
+    b: ["c1", "f1"],
+  },
+  b: {
+    n: ["b8", "g8"],
+    b: ["c8", "f8"],
+  },
+};
+
+export type GamePhase = "opening" | "middlegame" | "endgame";
+
+export interface CoachingInsights {
+  comment: string;
+  voiceLine: string;
+  baseComment: string;
+  evaluation: number;
+  evaluationLabel: string;
+  advantage: "white" | "black" | "balanced";
+  perspective: 'w' | 'b';
+  opening?: OpeningMatch;
+  gamePhase: GamePhase;
+  tacticHighlight?: string;
+  keyIdeas: string[];
+  suggestions: string[];
+  riskWarnings: string[];
+  engineAdvice?: string;
+}
+
+interface AnalysisContext {
+  chess: Chess;
+  move: Move;
+  history: Move[];
+  perspective: 'w' | 'b';
+  isOpponentMove?: boolean;
+  labelPrefix?: string;
+}
+
+export function analyzePlayerMove({ chess, move, history }: { chess: Chess; move: Move; history: Move[]; }): CoachingInsights {
+  return buildInsights({ chess, move, history, perspective: move.color, isOpponentMove: false });
+}
+
+export function analyzeAIMove({ chess, move, history }: { chess: Chess; move: Move; history: Move[]; }): CoachingInsights {
+  const perspective: 'w' | 'b' = move.color === 'w' ? 'b' : 'w';
+  return buildInsights({ chess, move, history, perspective, isOpponentMove: true, labelPrefix: "IA" });
+}
+
+export function withEngineAdvice(insights: CoachingInsights, advice: string, prefix?: string): CoachingInsights {
+  const finalMessage = prefix ? `${prefix}: ${advice}` : advice;
+  return {
+    ...insights,
+    comment: finalMessage,
+    voiceLine: finalMessage,
+    engineAdvice: advice,
+  };
+}
+
+function buildInsights({ chess, move, history, perspective, isOpponentMove, labelPrefix }: AnalysisContext): CoachingInsights {
+  const evaluation = evaluatePosition(chess);
+  const evaluationLabel = getEvaluationLabel(evaluation);
+  const advantage = evaluation > 0.7 ? "white" : evaluation < -0.7 ? "black" : "balanced";
+  const perspectiveScore = perspective === 'w' ? evaluation : -evaluation;
+  const sanitizedHistory = sanitizeSanMoves(history.map((item) => item.san));
+  const opening = detectOpeningFromHistory(sanitizedHistory);
+  const gamePhase = determineGamePhase(chess, history);
+  const tacticHighlight = detectTactic(move, isOpponentMove ?? false);
+  const keyIdeas = buildKeyIdeas(gamePhase, perspectiveScore, perspective, opening);
+  const suggestions = buildSuggestions({ chess, move, perspective, perspectiveScore, gamePhase, opening, isOpponentMove: isOpponentMove ?? false, history });
+  const riskWarnings = detectRisks({ chess, perspective, perspectiveScore, history, isOpponentMove: isOpponentMove ?? false, gamePhase });
+
+  const moveDescription = isOpponentMove ? describeOpponentMove(move) : describePlayerMove(move);
+  const evaluationMessage = createEvaluationMessage(perspectiveScore, perspective, isOpponentMove ?? false);
+
+  const segments: string[] = [];
+  if (opening && (opening.matchedMoves >= 2 || sanitizedHistory.length <= opening.moves.length + 2)) {
+    segments.push(`Ouverture ${opening.name}${opening.variation ? ` (${opening.variation})` : ""}.`);
+  }
+  if (moveDescription) {
+    segments.push(moveDescription);
+  }
+  if (tacticHighlight && tacticHighlight !== moveDescription) {
+    segments.push(tacticHighlight);
+  }
+  if (evaluationMessage) {
+    segments.push(evaluationMessage);
+  }
+
+  const baseComment = segments.join(' ');
+  const comment = labelPrefix ? `${labelPrefix}: ${baseComment}` : baseComment;
+
+  return {
+    comment,
+    voiceLine: comment,
+    baseComment,
+    evaluation,
+    evaluationLabel,
+    advantage,
+    perspective,
+    opening,
+    gamePhase,
+    tacticHighlight: isOpponentMove && tacticHighlight ? `Adversaire: ${tacticHighlight}` : tacticHighlight,
+    keyIdeas,
+    suggestions,
+    riskWarnings,
+  };
+}
+
+function evaluatePosition(chess: Chess): number {
+  const board = chess.board();
+  let score = 0;
+
+  board.forEach((row, rankIndex) => {
+    row.forEach((piece, fileIndex) => {
+      if (!piece) return;
+      const value = PIECE_VALUES[piece.type] ?? 0;
+      const sign = piece.color === 'w' ? 1 : -1;
+      score += value * sign;
+
+      const square = `${"abcdefgh"[fileIndex]}${8 - rankIndex}`;
+      if (CENTER.has(square)) {
+        score += 0.12 * sign;
+      } else if (EXTENDED_CENTER.has(square)) {
+        score += 0.05 * sign;
+      }
+
+      const startSquares = START_SQUARES[piece.color]?.[piece.type];
+      if (startSquares && !startSquares.includes(square)) {
+        score += 0.04 * sign;
+      }
+    });
+  });
+
+  return Math.round(score * 100) / 100;
+}
+
+function determineGamePhase(chess: Chess, history: Move[]): GamePhase {
+  const piecesLeft = chess.board().flat().filter(Boolean).length;
+  if (piecesLeft <= 10 || history.length >= 40) return "endgame";
+  if (history.length > 20 || piecesLeft <= 20) return "middlegame";
+  return "opening";
+}
+
+function buildKeyIdeas(gamePhase: GamePhase, perspectiveScore: number, perspective: 'w' | 'b', opening?: OpeningMatch): string[] {
+  const ideas = new Set<string>();
+
+  if (opening) {
+    opening.ideas.slice(0, 2).forEach((idea) => ideas.add(idea));
+  }
+
+  if (gamePhase === "opening") {
+    ideas.add("Développez vos pièces actives vers le centre");
+    if (perspectiveScore >= 0.5) {
+      ideas.add("Profitez de l'espace pour coordonner vos pièces lourdes");
+    } else {
+      ideas.add("Complétez votre développement avant d'ouvrir le jeu");
+    }
+  } else if (gamePhase === "middlegame") {
+    ideas.add("Cherchez les alignements tactiques : clouages et fourchettes");
+    if (perspectiveScore >= 0.7) {
+      ideas.add("Convertissez l'avantage en ouvrant une colonne pour les tours");
+    } else if (perspectiveScore <= -0.7) {
+      ideas.add("Simplifiez la position et neutralisez l'initiative adverse");
+    } else {
+      ideas.add("Améliorez la position de vos pièces une par une");
+    }
+  } else {
+    ideas.add("Activez votre roi : dirigez-le vers le centre");
+    ideas.add("Créez un pion passé ou bloquez celui de l'adversaire");
+  }
+
+  return Array.from(ideas).slice(0, 3);
+}
+
+interface SuggestionContext {
+  chess: Chess;
+  move: Move;
+  perspective: 'w' | 'b';
+  perspectiveScore: number;
+  gamePhase: GamePhase;
+  opening?: OpeningMatch;
+  isOpponentMove: boolean;
+  history: Move[];
+}
+
+function buildSuggestions({ chess, move, perspective, perspectiveScore, gamePhase, opening, isOpponentMove, history }: SuggestionContext): string[] {
+  const suggestions = new Set<string>();
+
+  if (!isOpponentMove) {
+    if (move.captured) {
+      suggestions.add("Stabilisez la pièce qui vient de capturer pour éviter une contre-attaque");
+    }
+    if (move.san === "O-O" || move.san === "O-O-O") {
+      suggestions.add("Connectez vos tours pour préparer le jeu des colonnes");
+    }
+  } else {
+    if (chess.in_check()) {
+      suggestions.add("Parer l'échec immédiatement : fuite du roi, blocage ou capture");
+    }
+    if (move.captured) {
+      suggestions.add("Évaluez les recaptures disponibles pour rétablir le matériel");
+    }
+  }
+
+  if (gamePhase === "opening") {
+    if (!hasCastled(history, perspective)) {
+      suggestions.add("Roquez pour mettre votre roi à l'abri");
+    }
+    suggestions.add("Terminez le développement des pièces mineures avant d'attaquer");
+  } else if (gamePhase === "middlegame") {
+    if (perspectiveScore >= 0.8) {
+      suggestions.add("Ouvrez les lignes sur l'aile où vous êtes mieux placé");
+    } else if (perspectiveScore <= -0.8) {
+      suggestions.add("Cherchez des échanges favorables pour soulager la pression");
+    } else {
+      suggestions.add("Coordonnez dame et tours sur une colonne semi-ouverte");
+    }
+  } else {
+    suggestions.add("Amenez votre roi vers l'action tout en gardant la sécurité");
+    if (perspectiveScore >= 0.8) {
+      suggestions.add("Utilisez votre majorité de pions pour créer un pion passé");
+    }
+  }
+
+  if (opening && opening.ideas.length) {
+    suggestions.add(opening.ideas[0]);
+  }
+
+  return Array.from(suggestions).slice(0, 3);
+}
+
+interface RiskContext {
+  chess: Chess;
+  perspective: 'w' | 'b';
+  perspectiveScore: number;
+  history: Move[];
+  isOpponentMove: boolean;
+  gamePhase: GamePhase;
+}
+
+function detectRisks({ chess, perspective, perspectiveScore, history, isOpponentMove, gamePhase }: RiskContext): string[] {
+  const warnings: string[] = [];
+
+  if (isOpponentMove && chess.in_check()) {
+    warnings.push("Votre roi est en échec, réagissez immédiatement");
+  }
+
+  if (!hasCastled(history, perspective) && gamePhase === "opening" && history.length >= 8) {
+    warnings.push("Votre roi reste au centre, pensez à roquer sans tarder");
+  }
+
+  if (perspectiveScore <= -1.5) {
+    warnings.push("Le matériel est défavorable, cherchez des ressources tactiques");
+  }
+
+  return warnings.slice(0, 2);
+}
+
+function getEvaluationLabel(evaluation: number): string {
+  if (evaluation > 1.5) return "Large avantage blanc";
+  if (evaluation > 0.8) return "Avantage blanc";
+  if (evaluation > 0.3) return "Initiative blanche";
+  if (evaluation < -1.5) return "Large avantage noir";
+  if (evaluation < -0.8) return "Avantage noir";
+  if (evaluation < -0.3) return "Initiative noire";
+  return "Équilibre";
+}
+
+function createEvaluationMessage(score: number, perspective: 'w' | 'b', isOpponentMove: boolean): string {
+  const advantageText = perspective === 'w' ? "vous" : "vous"; // uniform phrasing
+  if (score > 1.5) {
+    return isOpponentMove
+      ? "Vous conservez un net avantage, convertissez-le méthodiquement"
+      : "Vous avez un large avantage, transformez-le en attaque directe";
+  }
+  if (score > 0.7) {
+    return isOpponentMove
+      ? "L'initiative est pour vous, continuez à améliorer vos pièces"
+      : "Vous gardez l'initiative, multipliez les menaces";
+  }
+  if (score < -1.5) {
+    return isOpponentMove
+      ? "Attention, l'adversaire prend un sérieux avantage"
+      : "La position est critique, cherchez du contre-jeu immédiat";
+  }
+  if (score < -0.7) {
+    return isOpponentMove
+      ? "Position délicate, stabilisez votre défense"
+      : "L'adversaire prend l'initiative, solidifiez votre camp";
+  }
+  return isOpponentMove
+    ? "La position reste équilibrée, cherchez le plan le plus actif"
+    : "Position équilibrée, continuez à appliquer vos principes";
+}
+
+function describePlayerMove(move: Move): string {
+  if (move.san === "O-O") return "Roque du petit côté : votre roi est en sécurité";
+  if (move.san === "O-O-O") return "Roque long audacieux, surveillez l'aile dame";
+  if (move.promotion) {
+    const promoted = PIECE_NAMES[move.promotion] ?? "pièce";
+    return `Promotion : votre pion devient une ${promoted} sur ${move.to}`;
+  }
+  if (move.captured) {
+    const capturedName = PIECE_NAMES[move.captured] ?? "pièce";
+    const pieceName = PIECE_NAMES[move.piece] ?? "pièce";
+    return `Belle prise : votre ${pieceName} capture ${capturedName} en ${move.to}`;
+  }
+  if (move.san.includes("+")) {
+    return "Échec donné au roi adverse, profitez de l'initiative";
+  }
+  const pieceName = PIECE_NAMES[move.piece] ?? "pièce";
+  return `Votre ${pieceName} rejoint la case ${move.to} et gagne de l'activité`;
+}
+
+function describeOpponentMove(move: Move): string {
+  if (move.san === "O-O") return "L'adversaire roque du petit côté, son roi est à l'abri";
+  if (move.san === "O-O-O") return "Roque long adverse, ciblez l'aile dame";
+  if (move.promotion) {
+    const promoted = PIECE_NAMES[move.promotion] ?? "pièce";
+    return `L'adversaire promeut un pion en ${promoted} sur ${move.to}`;
+  }
+  if (move.captured) {
+    const capturedName = PIECE_NAMES[move.captured] ?? "pièce";
+    const pieceName = PIECE_NAMES[move.piece] ?? "pièce";
+    return `Attention : ${pieceName} adverse capture votre ${capturedName} en ${move.to}`;
+  }
+  if (move.san.includes("+")) {
+    return "L'adversaire vous met en échec, trouvez la meilleure parade";
+  }
+  const pieceName = PIECE_NAMES[move.piece] ?? "pièce";
+  return `L'adversaire développe son ${pieceName} vers ${move.to}`;
+}
+
+function detectTactic(move: Move, isOpponentMove: boolean): string | undefined {
+  if (move.san.includes("#")) {
+    return isOpponentMove ? "Échec et mat subi" : "Échec et mat immédiat";
+  }
+  if (move.san.includes("+")) {
+    return isOpponentMove ? "L'adversaire vous met en échec" : "Échec infligé au roi adverse";
+  }
+  if (move.promotion) {
+    const promoted = PIECE_NAMES[move.promotion] ?? "pièce";
+    return isOpponentMove ? `Promotion adverse en ${promoted}` : `Promotion en ${promoted}`;
+  }
+  if (move.captured) {
+    const capturedName = PIECE_NAMES[move.captured] ?? "pièce";
+    return isOpponentMove
+      ? `Votre ${capturedName} vient de tomber, soyez attentif`
+      : `Vous gagnez du matériel en capturant ${capturedName}`;
+  }
+  return undefined;
+}
+
+function hasCastled(history: Move[], color: 'w' | 'b'): boolean {
+  return history.some((item) => item.color === color && (item.san === "O-O" || item.san === "O-O-O"));
+}

--- a/src/lib/openings.ts
+++ b/src/lib/openings.ts
@@ -1,0 +1,197 @@
+export interface OpeningDefinition {
+  eco: string;
+  name: string;
+  variation?: string;
+  moves: string[];
+  ideas: string[];
+}
+
+export interface OpeningMatch extends OpeningDefinition {
+  matchedMoves: number;
+}
+
+export const OPENING_BOOK: OpeningDefinition[] = [
+  {
+    eco: "C60",
+    name: "Partie espagnole",
+    variation: "Défense Morphy",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bb5"],
+    ideas: [
+      "Mettre la pression sur le cavalier c6 pour détériorer la structure noire",
+      "Préparer le roque et renforcer le contrôle du centre"
+    ]
+  },
+  {
+    eco: "B90",
+    name: "Défense sicilienne",
+    variation: "Najdorf",
+    moves: ["e4", "c5", "Nf3", "d6", "d4", "cxd4", "Nxd4", "Nf6", "Nc3", "a6"],
+    ideas: [
+      "Empêcher les pièces blanches de s'installer sur b5",
+      "Préparer ...e5 ou ...e6 pour contester le centre"
+    ]
+  },
+  {
+    eco: "C00",
+    name: "Défense française",
+    variation: "Classique",
+    moves: ["e4", "e6", "d4", "d5"],
+    ideas: [
+      "Avancer le pion d pour maintenir le centre",
+      "Surveiller la poussée ...c5 qui casse la chaîne de pions"
+    ]
+  },
+  {
+    eco: "B12",
+    name: "Défense carokann",
+    variation: "Classique",
+    moves: ["e4", "c6", "d4", "d5", "Nc3", "dxe4", "Nxe4"],
+    ideas: [
+      "Développer rapidement le fou de cases blanches",
+      "Jouer c4 ou Nf3 pour maintenir la pression centrale"
+    ]
+  },
+  {
+    eco: "A40",
+    name: "Ouverture Zukertort",
+    variation: "Moderne",
+    moves: ["d4", "Nf6", "Nf3", "e6", "g3"],
+    ideas: [
+      "Fianchetter le fou de cases blanches pour contrôler la diagonale longue",
+      "Préparer c4 pour exercer une pression sur le centre"
+    ]
+  },
+  {
+    eco: "D30",
+    name: "Gambit dame",
+    variation: "Classique",
+    moves: ["d4", "d5", "c4"],
+    ideas: [
+      "Laisser un pion en b et c pour ouvrir les lignes",
+      "Développer le fou de cases blanches vers g5"
+    ]
+  },
+  {
+    eco: "E60",
+    name: "Défense indienne du roi",
+    variation: "Classique",
+    moves: ["d4", "Nf6", "c4", "g6", "Nc3", "Bg7", "e4", "d6", "Nf3", "O-O"],
+    ideas: [
+      "Préparer ...e5 ou ...c5 pour frapper le centre",
+      "Attaquer le roi blanc via f5 et g4"
+    ]
+  },
+  {
+    eco: "C50",
+    name: "Partie italienne",
+    variation: "Giuoco Piano",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5"],
+    ideas: [
+      "Surveiller la poussée d4 pour ouvrir le centre",
+      "Coordonner les cavaliers vers g5 et d5"
+    ]
+  },
+  {
+    eco: "B01",
+    name: "Défense scandinave",
+    variation: "Classique",
+    moves: ["e4", "d5", "exd5", "Qxd5", "Nc3"],
+    ideas: [
+      "Gagner un tempo en attaquant la dame noire",
+      "Développer rapidement les pièces mineures"
+    ]
+  },
+  {
+    eco: "A80",
+    name: "Défense hollandaise",
+    variation: "Classique",
+    moves: ["d4", "f5", "g3", "Nf6", "Bg2", "e6"],
+    ideas: [
+      "Fianchetter le fou pour contrôler la diagonale",
+      "Préparer e4 pour ouvrir la colonne f"
+    ]
+  },
+  {
+    eco: "C41",
+    name: "Défense philidor",
+    variation: "Classique",
+    moves: ["e4", "e5", "Nf3", "d6"],
+    ideas: [
+      "Préparer d4 pour gagner de l'espace",
+      "Appuyer e5 avec Nc6 ou Nd7"
+    ]
+  },
+  {
+    eco: "B33",
+    name: "Sicilienne",
+    variation: "Sveshnikov",
+    moves: ["e4", "c5", "Nf3", "Nc6", "d4", "cxd4", "Nxd4", "Nf6", "Nc3", "e5"],
+    ideas: [
+      "Prendre de l'espace au centre avec ...e5",
+      "Anticiper Nd5 et préparer ...Be6"
+    ]
+  },
+  {
+    eco: "C65",
+    name: "Espagnole",
+    variation: "Berlin",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bb5", "Nf6"],
+    ideas: [
+      "Simplifier rapidement la position",
+      "Contrer la pression blanche sur e5"
+    ]
+  },
+  {
+    eco: "D90",
+    name: "Gambit dame refusé",
+    variation: "Tartakover",
+    moves: ["d4", "d5", "c4", "e6", "Nc3", "Nf6", "Bg5", "Be7", "e3", "h6", "Bh4", "O-O", "Nf3", "b6"],
+    ideas: [
+      "Solidifier la structure centrale",
+      "Préparer ...c5 pour l'égalisation"
+    ]
+  },
+  {
+    eco: "A07",
+    name: "Ouverture Bird",
+    variation: "Classique",
+    moves: ["f4", "d5", "Nf3", "g6"],
+    ideas: [
+      "Contrôler e5 avec le pion f",
+      "Préparer e4 pour construire un duo de pions"
+    ]
+  }
+];
+
+const SAN_CLEANUP = /[+#?!]/g;
+
+export function detectOpeningFromHistory(history: string[]): OpeningMatch | undefined {
+  if (!history.length) return undefined;
+
+  let bestMatch: OpeningMatch | undefined;
+
+  for (const opening of OPENING_BOOK) {
+    if (history.length < opening.moves.length) {
+      const partial = opening.moves.slice(0, history.length);
+      if (partial.every((move, index) => move === history[index])) {
+        if (!bestMatch || partial.length > bestMatch.matchedMoves) {
+          bestMatch = { ...opening, matchedMoves: partial.length };
+        }
+      }
+      continue;
+    }
+
+    const matches = opening.moves.every((move, index) => move === history[index]);
+    if (matches) {
+      if (!bestMatch || opening.moves.length > bestMatch.matchedMoves) {
+        bestMatch = { ...opening, matchedMoves: opening.moves.length };
+      }
+    }
+  }
+
+  return bestMatch;
+}
+
+export function sanitizeSanMoves(moves: string[]): string[] {
+  return moves.map((san) => san.replace(SAN_CLEANUP, ""));
+}


### PR DESCRIPTION
## Summary
- introduce a reusable chess analysis module that evaluates positions, detects openings, and prepares coaching insights
- refresh the coaching panel with structured feedback, evaluation gauges, and improved speech synthesis options for a more natural voice
- wire real-time analysis into the chess game flow while retaining remote advice, updating speech handling, and exposing richer coaching data in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc8cf607c88323b667fcbce44a73d4