### PR TITLE
feat: add coach language controls and special attack button

### DIFF
--- a/src/components/CoachingPanel.tsx
+++ b/src/components/CoachingPanel.tsx
@@ -4,44 +4,50 @@ import { Progress } from "@/components/ui/progress";
 import { Brain, MessageCircle, Trophy, AlertCircle, Sparkles } from "lucide-react";
 import useSpeechSynthesis from "@/hooks/use-speech";
 import type { CoachingInsights } from "@/lib/chessAnalysis";
+import { getCoachLanguageConfig, type CoachLanguage } from "@/lib/coachLanguage";
 
 interface CoachingPanelProps {
   comment: string;
   analysis?: CoachingInsights | null;
   isAnalyzing?: boolean;
+  language: CoachLanguage;
+  isEnabled: boolean;
 }
 
-export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelProps) {
-  const fallbackSpeech = comment.includes("Analyse en cours") ? "" : comment;
-  const spokenText = analysis?.voiceLine ?? fallbackSpeech;
+export function CoachingPanel({ comment, analysis, isAnalyzing, language, isEnabled }: CoachingPanelProps) {
+  const config = getCoachLanguageConfig(language);
+  const spokenText = isEnabled ? analysis?.voiceLine ?? comment ?? config.defaultComment : "";
+
   useSpeechSynthesis(spokenText, {
-    voicePreferences: ["Google français", "Amelie", "Thomas"],
-    rate: 0.94,
-    pitch: 1.04,
-    volume: 0.9,
+    voicePreferences: config.speech.voicePreferences,
+    rate: config.speech.rate,
+    pitch: config.speech.pitch,
+    volume: config.speech.volume,
   });
 
   const getCommentType = () => {
     if (isAnalyzing) {
-      return { icon: Brain, color: "text-blue-400", bg: "bg-blue-500/10", label: "Analyse" };
+      return { icon: Brain, color: "text-blue-400", bg: "bg-blue-500/10", label: config.statuses.analyzing };
     }
     if (analysis?.engineAdvice) {
-      return { icon: Brain, color: "text-sky-400", bg: "bg-sky-500/10", label: "Analyse experte" };
+      return { icon: Brain, color: "text-sky-400", bg: "bg-sky-500/10", label: config.statuses.expert };
     }
     if (analysis?.riskWarnings?.length) {
-      return { icon: AlertCircle, color: "text-amber-400", bg: "bg-amber-500/10", label: "Attention" };
+      return { icon: AlertCircle, color: "text-amber-400", bg: "bg-amber-500/10", label: config.statuses.warning };
     }
     if (analysis?.advantage === "white" || analysis?.advantage === "black") {
-      return { icon: Trophy, color: "text-emerald-400", bg: "bg-emerald-500/10", label: "Avantage" };
+      return { icon: Trophy, color: "text-emerald-400", bg: "bg-emerald-500/10", label: config.statuses.advantage };
     }
-    return { icon: MessageCircle, color: "text-primary", bg: "bg-primary/10", label: "Conseil" };
+    return { icon: MessageCircle, color: "text-primary", bg: "bg-primary/10", label: config.statuses.advice };
   };
 
   const { icon: Icon, color, bg, label } = getCommentType();
   const evaluationPercent = analysis ? Math.max(0, Math.min(100, Math.round(50 + analysis.evaluation * 10))) : 50;
-  const evaluationLabel = analysis?.evaluationLabel ?? "Évaluation en cours";
-  const defaultComment = comment || "Analysez vos coups et ceux de l'adversaire pour progresser...";
-  const mainMessage = analysis?.comment ?? (isAnalyzing ? "Analyse en cours..." : defaultComment);
+  const evaluationLabel = analysis?.evaluationLabel ?? config.evaluationHeading;
+  const defaultComment = comment || config.defaultComment;
+  const mainMessage = analysis?.comment ?? (isAnalyzing ? config.analyzingFooter : defaultComment);
+
+  const moveCountLabel = (count: number) => `${count} ${count > 1 ? config.moveWord.plural : config.moveWord.singular}`;
 
   return (
     <Card className={`p-4 gradient-card border-chess ${bg}`}>
@@ -49,7 +55,7 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
         <Icon className={`w-5 h-5 ${color} mt-0.5 flex-shrink-0`} />
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-2">
-            <span className="font-semibold">Coach IA</span>
+            <span className="font-semibold">{config.coachTitle}</span>
             <Badge variant="outline" className={`text-xs ${color}`}>
               {label}
             </Badge>
@@ -59,11 +65,11 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
               <div>
                 <p className="font-medium">{analysis.opening.name}{analysis.opening.variation ? ` (${analysis.opening.variation})` : ""}</p>
                 <p className="text-muted-foreground">
-                  {analysis.opening.eco} • {analysis.opening.matchedMoves} coup{analysis.opening.matchedMoves > 1 ? "s" : ""}
+                  {analysis.opening.eco} • {moveCountLabel(analysis.opening.matchedMoves)}
                 </p>
               </div>
               <Badge variant="secondary" className="ml-2">
-                {analysis.gamePhase === "opening" ? "Ouverture" : analysis.gamePhase === "middlegame" ? "Milieu de jeu" : "Finale"}
+                {config.phaseLabels[analysis.gamePhase]}
               </Badge>
             </div>
           )}
@@ -73,31 +79,33 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
       <div className="text-sm leading-relaxed">
         {analysis?.engineAdvice && analysis.baseComment !== analysis.comment && (
           <div className="mb-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">Analyse instantanée :</span> {analysis.baseComment}
+            <span className="font-medium text-foreground">{config.instantAnalysisPrefix}</span> {analysis.baseComment}
           </div>
         )}
-        {mainMessage || "Analysez vos coups et ceux de l'adversaire pour progresser..."}
+        {mainMessage || config.defaultComment}
       </div>
 
       {analysis && (
         <div className="mt-4">
           <div className="flex items-center justify-between text-xs font-semibold">
-            <span>Évaluation</span>
-            <span className={
-              analysis.advantage === "white"
-                ? "text-emerald-400"
-                : analysis.advantage === "black"
-                  ? "text-rose-400"
-                  : "text-muted-foreground"
-            }>
+            <span>{config.evaluationHeading}</span>
+            <span
+              className={
+                analysis.advantage === "white"
+                  ? "text-emerald-400"
+                  : analysis.advantage === "black"
+                    ? "text-rose-400"
+                    : "text-muted-foreground"
+              }
+            >
               {evaluationLabel} ({analysis.evaluation >= 0 ? "+" : ""}{analysis.evaluation.toFixed(2)})
             </span>
           </div>
           <Progress value={evaluationPercent} className="h-2 mt-2" />
           <div className="mt-1 flex justify-between text-[10px] text-muted-foreground uppercase tracking-wide">
-            <span>Avantage noir</span>
-            <span>Équilibre</span>
-            <span>Avantage blanc</span>
+            <span>{config.evaluationScale.black}</span>
+            <span>{config.evaluationScale.balanced}</span>
+            <span>{config.evaluationScale.white}</span>
           </div>
         </div>
       )}
@@ -111,7 +119,7 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
 
       {analysis?.keyIdeas?.length ? (
         <div className="mt-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Idées clés</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{config.keyIdeasTitle}</p>
           <ul className="mt-2 space-y-1 text-sm">
             {analysis.keyIdeas.map((idea, index) => (
               <li key={index} className="flex items-start gap-2">
@@ -125,7 +133,7 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
 
       {analysis?.suggestions?.length ? (
         <div className="mt-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Plans recommandés</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{config.plansTitle}</p>
           <ul className="mt-2 space-y-1 text-sm">
             {analysis.suggestions.map((tip, index) => (
               <li key={index} className="flex items-start gap-2">
@@ -141,7 +149,7 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
         <div className="mt-4 rounded-md bg-red-500/10 px-3 py-2 text-xs text-red-300">
           <div className="mb-1 flex items-center gap-2 font-semibold">
             <AlertCircle className="h-3.5 w-3.5" />
-            <span>Points de vigilance</span>
+            <span>{config.warningsTitle}</span>
           </div>
           <ul className="space-y-1">
             {analysis.riskWarnings.map((warning, index) => (
@@ -153,11 +161,11 @@ export function CoachingPanel({ comment, analysis, isAnalyzing }: CoachingPanelP
 
       <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
         <div className="flex space-x-1">
-          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: '0s' }} />
-          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: '0.2s' }} />
-          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: '0.4s' }} />
+          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "0s" }} />
+          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "0.2s" }} />
+          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "0.4s" }} />
         </div>
-        <span>{isAnalyzing ? "Analyse experte en cours" : "Analyse en temps réel"}</span>
+        <span>{isAnalyzing ? config.analyzingFooter : config.realtimeFooter}</span>
       </div>
     </Card>
   );

--- a/src/lib/coachLanguage.ts
+++ b/src/lib/coachLanguage.ts
@@ -1,0 +1,609 @@
+import type { CoachingInsights } from "./chessAnalysis";
+
+export type CoachLanguage = "fr" | "en" | "es";
+
+interface CoachLanguageConfig {
+  label: string;
+  coachTitle: string;
+  disabledMessage: string;
+  statuses: {
+    analyzing: string;
+    expert: string;
+    warning: string;
+    advantage: string;
+    advice: string;
+  };
+  instantAnalysisPrefix: string;
+  defaultComment: string;
+  evaluationHeading: string;
+  evaluationScale: {
+    black: string;
+    balanced: string;
+    white: string;
+  };
+  phaseLabels: {
+    opening: string;
+    middlegame: string;
+    endgame: string;
+  };
+  keyIdeasTitle: string;
+  plansTitle: string;
+  warningsTitle: string;
+  analyzingFooter: string;
+  realtimeFooter: string;
+  moveWord: {
+    singular: string;
+    plural: string;
+  };
+  speech: {
+    voicePreferences: string[];
+    rate: number;
+    pitch: number;
+    volume: number;
+  };
+  opponentPrefix: string;
+  enginePrefix: string;
+}
+
+const LANGUAGE_CONFIG: Record<CoachLanguage, CoachLanguageConfig> = {
+  fr: {
+    label: "Français",
+    coachTitle: "Coach IA",
+    disabledMessage: "Coach désactivé. Activez-le pour recevoir des commentaires en direct.",
+    statuses: {
+      analyzing: "Analyse",
+      expert: "Analyse experte",
+      warning: "Attention",
+      advantage: "Avantage",
+      advice: "Conseil",
+    },
+    instantAnalysisPrefix: "Analyse instantanée :",
+    defaultComment: "Analysez vos coups et ceux de l'adversaire pour progresser...",
+    evaluationHeading: "Évaluation",
+    evaluationScale: {
+      black: "Avantage noir",
+      balanced: "Équilibre",
+      white: "Avantage blanc",
+    },
+    phaseLabels: {
+      opening: "Ouverture",
+      middlegame: "Milieu de jeu",
+      endgame: "Finale",
+    },
+    keyIdeasTitle: "Idées clés",
+    plansTitle: "Plans recommandés",
+    warningsTitle: "Points de vigilance",
+    analyzingFooter: "Analyse experte en cours",
+    realtimeFooter: "Analyse en temps réel",
+    moveWord: {
+      singular: "coup",
+      plural: "coups",
+    },
+    speech: {
+      voicePreferences: ["Google français", "Amelie", "Thomas", "fr-FR"],
+      rate: 0.94,
+      pitch: 1.04,
+      volume: 0.9,
+    },
+    opponentPrefix: "Adversaire",
+    enginePrefix: "IA",
+  },
+  en: {
+    label: "English",
+    coachTitle: "AI Coach",
+    disabledMessage: "Coach disabled. Enable it to receive live feedback.",
+    statuses: {
+      analyzing: "Analysis",
+      expert: "Expert insight",
+      warning: "Warning",
+      advantage: "Advantage",
+      advice: "Advice",
+    },
+    instantAnalysisPrefix: "Instant analysis:",
+    defaultComment: "Review your moves and your opponent's to keep improving...",
+    evaluationHeading: "Evaluation",
+    evaluationScale: {
+      black: "Black edge",
+      balanced: "Balance",
+      white: "White edge",
+    },
+    phaseLabels: {
+      opening: "Opening",
+      middlegame: "Middlegame",
+      endgame: "Endgame",
+    },
+    keyIdeasTitle: "Key ideas",
+    plansTitle: "Recommended plans",
+    warningsTitle: "Watch out",
+    analyzingFooter: "Expert analysis in progress",
+    realtimeFooter: "Live analysis",
+    moveWord: {
+      singular: "move",
+      plural: "moves",
+    },
+    speech: {
+      voicePreferences: ["Google US English", "Samantha", "Alex", "en-US"],
+      rate: 1,
+      pitch: 1,
+      volume: 0.9,
+    },
+    opponentPrefix: "Opponent",
+    enginePrefix: "AI",
+  },
+  es: {
+    label: "Español",
+    coachTitle: "Coach IA",
+    disabledMessage: "Coach desactivado. Actívalo para recibir comentarios en directo.",
+    statuses: {
+      analyzing: "Análisis",
+      expert: "Análisis experto",
+      warning: "Atención",
+      advantage: "Ventaja",
+      advice: "Consejo",
+    },
+    instantAnalysisPrefix: "Análisis instantáneo:",
+    defaultComment: "Analiza tus jugadas y las del rival para seguir progresando...",
+    evaluationHeading: "Evaluación",
+    evaluationScale: {
+      black: "Ventaja negra",
+      balanced: "Equilibrio",
+      white: "Ventaja blanca",
+    },
+    phaseLabels: {
+      opening: "Apertura",
+      middlegame: "Medio juego",
+      endgame: "Final",
+    },
+    keyIdeasTitle: "Ideas clave",
+    plansTitle: "Planes recomendados",
+    warningsTitle: "Puntos de vigilancia",
+    analyzingFooter: "Análisis experto en curso",
+    realtimeFooter: "Análisis en tiempo real",
+    moveWord: {
+      singular: "jugada",
+      plural: "jugadas",
+    },
+    speech: {
+      voicePreferences: ["Google español", "Monica", "Jorge", "es-ES"],
+      rate: 0.98,
+      pitch: 1,
+      volume: 0.9,
+    },
+    opponentPrefix: "Oponente",
+    enginePrefix: "IA",
+  },
+};
+
+export const coachLanguageOptions = (Object.keys(LANGUAGE_CONFIG) as CoachLanguage[]).map((key) => ({
+  value: key,
+  label: LANGUAGE_CONFIG[key].label,
+}));
+
+export function getCoachLanguageConfig(language: CoachLanguage): CoachLanguageConfig {
+  return LANGUAGE_CONFIG[language];
+}
+
+const PIECE_TRANSLATIONS: Record<string, { en: string; es: string }> = {
+  pion: { en: "pawn", es: "peón" },
+  cavalier: { en: "knight", es: "caballo" },
+  fou: { en: "bishop", es: "alfil" },
+  tour: { en: "rook", es: "torre" },
+  dame: { en: "queen", es: "dama" },
+  roi: { en: "king", es: "rey" },
+  pièce: { en: "piece", es: "pieza" },
+};
+
+const EXACT_TRANSLATIONS: Record<string, { en: string; es: string }> = {
+  "Roque du petit côté : votre roi est en sécurité": {
+    en: "Kingside castling keeps your king safe",
+    es: "Enroque corto: tu rey queda a salvo",
+  },
+  "Roque long audacieux, surveillez l'aile dame": {
+    en: "Bold queenside castling, watch the queenside",
+    es: "Enroque largo audaz, vigila el flanco de dama",
+  },
+  "Échec donné au roi adverse, profitez de l'initiative": {
+    en: "Check delivered to the enemy king, press the initiative",
+    es: "Jaque al rey rival, aprovecha la iniciativa",
+  },
+  "L'adversaire roque du petit côté, son roi est à l'abri": {
+    en: "Opponent castles short, their king is safer",
+    es: "El rival enroca corto, su rey está a salvo",
+  },
+  "Roque long adverse, ciblez l'aile dame": {
+    en: "Opponent castles long, target the queenside",
+    es: "Enroque largo rival, apunta al flanco de dama",
+  },
+  "L'adversaire vous met en échec, trouvez la meilleure parade": {
+    en: "Opponent gives check, find the best defence",
+    es: "El rival da jaque, busca la mejor defensa",
+  },
+  "Échec et mat immédiat": {
+    en: "Immediate checkmate",
+    es: "Jaque mate inmediato",
+  },
+  "Échec et mat subi": {
+    en: "Checkmate suffered",
+    es: "Jaque mate sufrido",
+  },
+  "Échec infligé au roi adverse": {
+    en: "Check delivered to the enemy king",
+    es: "Jaque al rey contrario",
+  },
+  "Vous gagnez du matériel en capturant pièce": {
+    en: "You gain material by capturing a piece",
+    es: "Ganas material capturando una pieza",
+  },
+  "Vous conservez un net avantage, convertissez-le méthodiquement": {
+    en: "You keep a clear edge, convert it methodically",
+    es: "Conservas una clara ventaja, conviértela con método",
+  },
+  "Vous avez un large avantage, transformez-le en attaque directe": {
+    en: "You have a large advantage, turn it into a direct attack",
+    es: "Tienes gran ventaja, transfórmala en un ataque directo",
+  },
+  "L'initiative est pour vous, continuez à améliorer vos pièces": {
+    en: "The initiative is yours, keep improving your pieces",
+    es: "La iniciativa es tuya, sigue mejorando tus piezas",
+  },
+  "Vous gardez l'initiative, multipliez les menaces": {
+    en: "You keep the initiative, multiply the threats",
+    es: "Mantienes la iniciativa, multiplica las amenazas",
+  },
+  "Attention, l'adversaire prend un sérieux avantage": {
+    en: "Careful, the opponent is taking a serious advantage",
+    es: "Atención, el rival obtiene una ventaja seria",
+  },
+  "La position est critique, cherchez du contre-jeu immédiat": {
+    en: "Critical position, look for immediate counterplay",
+    es: "Posición crítica, busca contrajuego inmediato",
+  },
+  "Position délicate, stabilisez votre défense": {
+    en: "Difficult position, stabilise your defence",
+    es: "Posición delicada, estabiliza tu defensa",
+  },
+  "L'adversaire prend l'initiative, solidifiez votre camp": {
+    en: "Opponent takes the initiative, solidify your camp",
+    es: "El rival toma la iniciativa, refuerza tu posición",
+  },
+  "La position reste équilibrée, cherchez le plan le plus actif": {
+    en: "Position remains balanced, look for the most active plan",
+    es: "La posición sigue equilibrada, busca el plan más activo",
+  },
+  "Position équilibrée, continuez à appliquer vos principes": {
+    en: "Balanced position, keep applying your principles",
+    es: "Posición equilibrada, sigue aplicando tus principios",
+  },
+  "Votre roi est en échec, réagissez immédiatement": {
+    en: "Your king is in check, respond immediately",
+    es: "Tu rey está en jaque, reacciona de inmediato",
+  },
+  "Votre roi reste au centre, pensez à roquer sans tarder": {
+    en: "Your king stays in the centre, castle without delay",
+    es: "Tu rey sigue en el centro, enroca sin tardar",
+  },
+  "Le matériel est défavorable, cherchez des ressources tactiques": {
+    en: "Material deficit, look for tactical resources",
+    es: "Desventaja material, busca recursos tácticos",
+  },
+  "Développez vos pièces actives vers le centre": {
+    en: "Develop your active pieces toward the centre",
+    es: "Desarrolla tus piezas activas hacia el centro",
+  },
+  "Profitez de l'espace pour coordonner vos pièces lourdes": {
+    en: "Use the space advantage to coordinate your heavy pieces",
+    es: "Aprovecha el espacio para coordinar tus piezas pesadas",
+  },
+  "Complétez votre développement avant d'ouvrir le jeu": {
+    en: "Complete your development before opening the game",
+    es: "Completa tu desarrollo antes de abrir el juego",
+  },
+  "Cherchez les alignements tactiques : clouages et fourchettes": {
+    en: "Look for tactical alignments: pins and forks",
+    es: "Busca alineaciones tácticas: clavadas y dobles ataques",
+  },
+  "Convertissez l'avantage en ouvrant une colonne pour les tours": {
+    en: "Convert the advantage by opening a file for the rooks",
+    es: "Convierte la ventaja abriendo una columna para las torres",
+  },
+  "Simplifiez la position et neutralisez l'initiative adverse": {
+    en: "Simplify the position and neutralise the opponent's initiative",
+    es: "Simplifica la posición y neutraliza la iniciativa rival",
+  },
+  "Améliorez la position de vos pièces une par une": {
+    en: "Improve your pieces one by one",
+    es: "Mejora la posición de tus piezas una por una",
+  },
+  "Activez votre roi : dirigez-le vers le centre": {
+    en: "Activate your king: guide it toward the centre",
+    es: "Activa tu rey: llévalo hacia el centro",
+  },
+  "Créez un pion passé ou bloquez celui de l'adversaire": {
+    en: "Create a passed pawn or stop the opponent's",
+    es: "Crea un peón pasado o bloquea el del rival",
+  },
+  "Stabilisez la pièce qui vient de capturer pour éviter une contre-attaque": {
+    en: "Stabilise the capturing piece to avoid counterplay",
+    es: "Estabiliza la pieza que capturó para evitar el contraataque",
+  },
+  "Connectez vos tours pour préparer le jeu des colonnes": {
+    en: "Connect your rooks to prepare file play",
+    es: "Conecta tus torres para preparar el juego por columnas",
+  },
+  "Parer l'échec immédiatement : fuite du roi, blocage ou capture": {
+    en: "Parry the check immediately: king move, block or capture",
+    es: "Neutraliza el jaque de inmediato: mueve el rey, bloquea o captura",
+  },
+  "Évaluez les recaptures disponibles pour rétablir le matériel": {
+    en: "Evaluate available recaptures to restore material balance",
+    es: "Evalúa las recapturas disponibles para igualar el material",
+  },
+  "Roquez pour mettre votre roi à l'abri": {
+    en: "Castle to shelter your king",
+    es: "Enroca para resguardar a tu rey",
+  },
+  "Terminez le développement des pièces mineures avant d'attaquer": {
+    en: "Finish minor-piece development before attacking",
+    es: "Termina el desarrollo de las piezas menores antes de atacar",
+  },
+  "Ouvrez les lignes sur l'aile où vous êtes mieux placé": {
+    en: "Open lines on the wing where you are better",
+    es: "Abre las líneas en el flanco donde estás mejor",
+  },
+  "Cherchez des échanges favorables pour soulager la pression": {
+    en: "Seek favourable exchanges to relieve pressure",
+    es: "Busca cambios favorables para aliviar la presión",
+  },
+  "Coordonnez dame et tours sur une colonne semi-ouverte": {
+    en: "Coordinate queen and rooks on a semi-open file",
+    es: "Coordina dama y torres en una columna semiabierta",
+  },
+  "Amenez votre roi vers l'action tout en gardant la sécurité": {
+    en: "Bring your king toward the action while staying safe",
+    es: "Acerca tu rey a la acción manteniendo la seguridad",
+  },
+  "Utilisez votre majorité de pions pour créer un pion passé": {
+    en: "Use your pawn majority to create a passed pawn",
+    es: "Usa tu mayoría de peones para crear un peón pasado",
+  },
+  "Analysez vos coups et ceux de l'adversaire pour progresser...": {
+    en: "Study your moves and the opponent's to keep improving...",
+    es: "Analiza tus jugadas y las del rival para seguir progresando...",
+  },
+  "Analyse en cours...": {
+    en: "Analysis in progress...",
+    es: "Análisis en curso...",
+  },
+};
+
+const EVAL_LABEL_TRANSLATIONS: Record<string, { en: string; es: string }> = {
+  "Large avantage blanc": { en: "Large white advantage", es: "Amplia ventaja blanca" },
+  "Avantage blanc": { en: "White advantage", es: "Ventaja blanca" },
+  "Initiative blanche": { en: "White initiative", es: "Iniciativa blanca" },
+  "Large avantage noir": { en: "Large black advantage", es: "Amplia ventaja negra" },
+  "Avantage noir": { en: "Black advantage", es: "Ventaja negra" },
+  "Initiative noire": { en: "Black initiative", es: "Iniciativa negra" },
+  "Équilibre": { en: "Balance", es: "Equilibrio" },
+};
+
+function translatePieceName(name: string, language: CoachLanguage): string {
+  if (language === "fr") return name;
+  const lower = name.toLowerCase();
+  const translation = PIECE_TRANSLATIONS[lower];
+  if (!translation) return name;
+  return translation[language];
+}
+
+interface PatternTranslation {
+  pattern: RegExp;
+  translate: (language: CoachLanguage, match: RegExpMatchArray) => string;
+}
+
+const PATTERN_TRANSLATIONS: PatternTranslation[] = [
+  {
+    pattern: /^Ouverture (.+?)(?: \((.+)\))?$/,
+    translate: (language, match) => {
+      if (language === "fr") {
+        return match[0];
+      }
+      const name = match[1];
+      const variation = match[2];
+      if (language === "en") {
+        return `Opening ${name}${variation ? ` (${variation})` : ""}`;
+      }
+      return `Apertura ${name}${variation ? ` (${variation})` : ""}`;
+    },
+  },
+  {
+    pattern: /^Promotion : votre pion devient une (.+) sur ([a-h][1-8])$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const square = match[2];
+      if (language === "en") {
+        return `Promotion: your pawn becomes a ${piece} on ${square}`;
+      }
+      return `Promoción: tu peón se convierte en ${piece} en ${square}`;
+    },
+  },
+  {
+    pattern: /^Belle prise : votre (.+) capture (.+) en ([a-h][1-8])$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const captured = translatePieceName(match[2], language);
+      const square = match[3];
+      if (language === "en") {
+        return `Great capture: your ${piece} captures ${captured} on ${square}`;
+      }
+      return `Gran captura: tu ${piece} captura ${captured} en ${square}`;
+    },
+  },
+  {
+    pattern: /^Votre (.+) rejoint la case ([a-h][1-8]) et gagne de l'activité$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const square = match[2];
+      if (language === "en") {
+        return `Your ${piece} reaches ${square} and gains activity`;
+      }
+      return `Tu ${piece} llega a ${square} y gana actividad`;
+    },
+  },
+  {
+    pattern: /^L'adversaire promeut un pion en (.+) sur ([a-h][1-8])$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const square = match[2];
+      if (language === "en") {
+        return `Opponent promotes a pawn to ${piece} on ${square}`;
+      }
+      return `El rival corona un peón en ${piece} en ${square}`;
+    },
+  },
+  {
+    pattern: /^Attention : (.+) adverse capture votre (.+) en ([a-h][1-8])$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const captured = translatePieceName(match[2], language);
+      const square = match[3];
+      if (language === "en") {
+        return `Watch out: enemy ${piece} captures your ${captured} on ${square}`;
+      }
+      return `Atención: el ${piece} rival captura tu ${captured} en ${square}`;
+    },
+  },
+  {
+    pattern: /^L'adversaire développe son (.+) vers ([a-h][1-8])$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      const square = match[2];
+      if (language === "en") {
+        return `Opponent develops their ${piece} toward ${square}`;
+      }
+      return `El rival desarrolla su ${piece} hacia ${square}`;
+    },
+  },
+  {
+    pattern: /^Promotion adverse en (.+)$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      if (language === "en") {
+        return `Opponent promotion to ${piece}`;
+      }
+      return `Promoción rival a ${piece}`;
+    },
+  },
+  {
+    pattern: /^Promotion en (.+)$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      if (language === "en") {
+        return `Promotion to ${piece}`;
+      }
+      return `Promoción a ${piece}`;
+    },
+  },
+  {
+    pattern: /^Votre (.+) vient de tomber, soyez attentif$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      if (language === "en") {
+        return `Your ${piece} just fell, stay alert`;
+      }
+      return `Tu ${piece} acaba de caer, mantente atento`;
+    },
+  },
+  {
+    pattern: /^Vous gagnez du matériel en capturant (.+)$/,
+    translate: (language, match) => {
+      if (language === "fr") return match[0];
+      const piece = translatePieceName(match[1], language);
+      if (language === "en") {
+        return `You gain material by capturing ${piece}`;
+      }
+      return `Ganas material capturando ${piece}`;
+    },
+  },
+];
+
+function translateSegment(segment: string, language: CoachLanguage): string {
+  if (language === "fr" || !segment) return segment;
+
+  const trimmed = segment.trim();
+  if (!trimmed) return trimmed;
+
+  const trailingPunctuation = /[.!?]$/.test(trimmed) ? trimmed.slice(-1) : "";
+  const core = trailingPunctuation ? trimmed.slice(0, -1) : trimmed;
+
+  if (core.startsWith("Adversaire: ")) {
+    const inner = core.slice("Adversaire: ".length).trim();
+    const translatedInner = translateSegment(inner, language);
+    const prefix = LANGUAGE_CONFIG[language].opponentPrefix;
+    const result = `${prefix}: ${translatedInner}`;
+    return trailingPunctuation ? `${result}${trailingPunctuation}` : result;
+  }
+
+  if (core.startsWith("IA: ")) {
+    const inner = core.slice("IA: ".length).trim();
+    const translatedInner = translateSegment(inner, language);
+    const prefix = LANGUAGE_CONFIG[language].enginePrefix;
+    const result = `${prefix}: ${translatedInner}`;
+    return trailingPunctuation ? `${result}${trailingPunctuation}` : result;
+  }
+
+  const exact = EXACT_TRANSLATIONS[core];
+  if (exact) {
+    const translated = exact[language];
+    return trailingPunctuation ? `${translated}${trailingPunctuation}` : translated;
+  }
+
+  for (const { pattern, translate } of PATTERN_TRANSLATIONS) {
+    const match = core.match(pattern);
+    if (match) {
+      const translated = translate(language, match);
+      return trailingPunctuation ? `${translated}${trailingPunctuation}` : translated;
+    }
+  }
+
+  return trailingPunctuation ? `${core}${trailingPunctuation}` : core;
+}
+
+export function translateCoachingText(text: string, language: CoachLanguage): string {
+  if (language === "fr" || !text) return text;
+  const segments = text.match(/[^.?!]+[.?!]?/g);
+  if (!segments) {
+    return translateSegment(text, language);
+  }
+  return segments.map((segment) => translateSegment(segment, language)).join(" ").trim();
+}
+
+export function translateCoachingInsights(insights: CoachingInsights, language: CoachLanguage): CoachingInsights {
+  if (language === "fr") return insights;
+
+  const translated: CoachingInsights = {
+    ...insights,
+    comment: translateCoachingText(insights.comment, language),
+    voiceLine: translateCoachingText(insights.voiceLine, language),
+    baseComment: translateCoachingText(insights.baseComment, language),
+    evaluationLabel: EVAL_LABEL_TRANSLATIONS[insights.evaluationLabel]?.[language] ?? insights.evaluationLabel,
+    tacticHighlight: insights.tacticHighlight ? translateCoachingText(insights.tacticHighlight, language) : undefined,
+    keyIdeas: insights.keyIdeas.map((idea) => translateCoachingText(idea, language)),
+    suggestions: insights.suggestions.map((tip) => translateCoachingText(tip, language)),
+    riskWarnings: insights.riskWarnings.map((warning) => translateCoachingText(warning, language)),
+    engineAdvice: insights.engineAdvice ? translateCoachingText(insights.engineAdvice, language) : undefined,
+  };
+
+  return translated;
+}
+
+export function getCoachDisabledMessage(language: CoachLanguage): string {
+  return LANGUAGE_CONFIG[language].disabledMessage;
+}


### PR DESCRIPTION
## Summary
- add a localization helper for translating coaching feedback and speech output
- update the coaching panel to support multiple languages and honor enable/disable state
- expose coach controls and a variant special-attack button on the game screen with translated messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc930b1ab88323aa7fe0384c725a9e