### PR TITLE
Fix chess.js compatibility issues

### DIFF
--- a/src/lib/chessAnalysis.ts
+++ b/src/lib/chessAnalysis.ts
@@ -33,6 +33,20 @@ const START_SQUARES: Record<'w' | 'b', Record<string, string[]>> = {
   },
 };
 
+function isKingInCheck(chess: Chess): boolean {
+  const modern = chess as Chess & { inCheck?: () => boolean };
+  if (typeof modern.inCheck === "function") {
+    return modern.inCheck();
+  }
+
+  const legacy = chess as Chess & { in_check?: () => boolean };
+  if (typeof legacy.in_check === "function") {
+    return legacy.in_check();
+  }
+
+  return false;
+}
+
 export type GamePhase = "opening" | "middlegame" | "endgame";
 
 export interface CoachingInsights {
@@ -218,7 +232,7 @@ function buildSuggestions({ chess, move, perspective, perspectiveScore, gamePhas
       suggestions.add("Connectez vos tours pour préparer le jeu des colonnes");
     }
   } else {
-    if (chess.in_check()) {
+    if (isKingInCheck(chess)) {
       suggestions.add("Parer l'échec immédiatement : fuite du roi, blocage ou capture");
     }
     if (move.captured) {
@@ -265,7 +279,7 @@ interface RiskContext {
 function detectRisks({ chess, perspective, perspectiveScore, history, isOpponentMove, gamePhase }: RiskContext): string[] {
   const warnings: string[] = [];
 
-  if (isOpponentMove && chess.in_check()) {
+  if (isOpponentMove && isKingInCheck(chess)) {
     warnings.push("Votre roi est en échec, réagissez immédiatement");
   }
 

--- a/src/lib/variantEngineAdapter.ts
+++ b/src/lib/variantEngineAdapter.ts
@@ -63,6 +63,19 @@ function deepCloneState(state: ExtendedGameState): ExtendedGameState {
   return JSON.parse(JSON.stringify(state));
 }
 
+function resolveFenChar(piece: Piece): string {
+  const mapped = pieceTypeToFen[piece.type as PieceType];
+  if (mapped) {
+    return mapped;
+  }
+
+  if (typeof piece.type === "string" && piece.type.length > 0) {
+    return piece.type.charAt(0).toLowerCase();
+  }
+
+  throw new Error(`Unsupported piece type: ${String(piece.type)}`);
+}
+
 export function algebraicToPos(square: string): Pos {
   const file = square.charCodeAt(0) - 97;
   const rank = parseInt(square[1], 10);
@@ -149,7 +162,7 @@ function boardToFen(board: Board): string {
         rankStr += empty.toString();
         empty = 0;
       }
-      const fenChar = pieceTypeToFen[piece.type];
+      const fenChar = resolveFenChar(piece);
       rankStr += piece.color === "white" ? fenChar.toUpperCase() : fenChar;
     }
     if (empty > 0) {


### PR DESCRIPTION
## Summary
- add a compatibility helper so analysis uses the correct chess.js in-check method across versions
- harden the chess.js adapter FEN conversion to cope with unexpected piece type strings instead of crashing

## Testing
- npm run lint *(fails: existing eslint complaints about explicit any usages and fast refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9e32b13c8323acd778ae590375e2