### PR TITLE
feat: add stockfish-based analysis pipeline

### DIFF
--- a/src/engine/stockfishClient.ts
+++ b/src/engine/stockfishClient.ts
@@ -1,0 +1,220 @@
+const DEFAULT_WASM_PATH = '/engines/stockfish.wasm';
+
+export interface AnalysePositionParams {
+  fen: string;
+  movetimeMs?: number;
+  nodes?: number;
+  multiPv?: number;
+}
+
+export interface PrincipalVariationLine {
+  multipv: number;
+  bestMove: string;
+  pv: string[];
+  evaluation: EngineEvaluation;
+}
+
+export interface EngineEvaluation {
+  type: 'cp' | 'mate';
+  value: number;
+}
+
+export interface AnalysePositionResult {
+  bestMove: string;
+  evaluation: EngineEvaluation;
+  lines: PrincipalVariationLine[];
+}
+
+export interface EngineHandle {
+  analysePosition(params: AnalysePositionParams): Promise<AnalysePositionResult>;
+  quit(): void;
+}
+
+const ENGINE_READY_MARKER = 'uciok';
+
+type StockfishFactory = (options?: Record<string, unknown>) => StockfishInstance | Promise<StockfishInstance>;
+
+type StockfishInstance = EventTarget & {
+  postMessage(message: string): void;
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<string>) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<string>) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+};
+
+async function ensureStockfishFactory(wasmUrl: string): Promise<StockfishFactory> {
+  const scriptUrl = wasmUrl.replace(/\.wasm$/, '.js');
+  const globalHandle = globalThis as unknown as { Stockfish?: StockfishFactory };
+  if (typeof globalHandle.Stockfish === 'function') {
+    return globalHandle.Stockfish;
+  }
+
+  await import(/* @vite-ignore */ scriptUrl);
+  if (typeof globalHandle.Stockfish !== 'function') {
+    throw new Error('Failed to load Stockfish factory script');
+  }
+
+  return globalHandle.Stockfish as StockfishFactory;
+}
+
+async function createEngineInstance(wasmUrl: string): Promise<StockfishInstance> {
+  const stockfishFactory = await ensureStockfishFactory(wasmUrl);
+  const wasmBinary = await fetch(wasmUrl).then((res) => res.arrayBuffer());
+  const instance = await Promise.resolve(stockfishFactory({ wasmBinary }));
+  if (!instance || typeof instance.postMessage !== 'function') {
+    throw new Error('Unexpected Stockfish WASM interface.');
+  }
+  return instance;
+}
+
+function parseEvaluation(payload: string): EngineEvaluation | null {
+  const mateMatch = payload.match(/mate (-?\d+)/);
+  if (mateMatch) {
+    return { type: 'mate', value: Number.parseInt(mateMatch[1], 10) };
+  }
+  const cpMatch = payload.match(/cp (-?\d+)/);
+  if (cpMatch) {
+    return { type: 'cp', value: Number.parseInt(cpMatch[1], 10) };
+  }
+  return null;
+}
+
+function parsePv(payload: string): string[] {
+  const pvMatch = payload.match(/ pv (.*)$/);
+  if (!pvMatch) return [];
+  return pvMatch[1].trim().split(/\s+/);
+}
+
+export async function initEngine(wasmUrl: string = DEFAULT_WASM_PATH): Promise<EngineHandle> {
+  const engine = await createEngineInstance(wasmUrl);
+  const listeners: ((message: string) => void)[] = [];
+  const waitForReady = new Promise<void>((resolve) => {
+    const handler = (event: MessageEvent<string>) => {
+      const text = event.data;
+      if (typeof text === 'string' && text.includes(ENGINE_READY_MARKER)) {
+        engine.removeEventListener('message', handler);
+        resolve();
+      }
+    };
+    engine.addEventListener('message', handler);
+  });
+
+  engine.addEventListener('message', (event: MessageEvent<string>) => {
+    const text = event.data;
+    if (typeof text !== 'string') return;
+    listeners.forEach((listener) => listener(text));
+  });
+
+  engine.postMessage('uci');
+  await waitForReady;
+
+  const sendCommand = (command: string) => {
+    engine.postMessage(command);
+  };
+
+  const onMessage = (listener: (payload: string) => void) => {
+    listeners.push(listener);
+    return () => {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    };
+  };
+
+  const analysePositionInternal = async ({
+    fen,
+    movetimeMs,
+    nodes,
+    multiPv = 1,
+  }: AnalysePositionParams): Promise<AnalysePositionResult> => {
+    const resultLines: PrincipalVariationLine[] = [];
+    let bestMove = '';
+    let finalEvaluation: EngineEvaluation = { type: 'cp', value: 0 };
+
+    const collectLine = (payload: string) => {
+      const multipvMatch = payload.match(/ multipv (\d+)/);
+      if (!multipvMatch) return;
+      const multipv = Number.parseInt(multipvMatch[1], 10);
+      const evaluation = parseEvaluation(payload);
+      if (!evaluation) return;
+      const pv = parsePv(payload);
+      const moveMatch = payload.match(/ pv (\w+)/);
+      const move = moveMatch ? moveMatch[1] : pv[0];
+      const existingIndex = resultLines.findIndex((line) => line.multipv === multipv);
+      const line: PrincipalVariationLine = {
+        multipv,
+        bestMove: move ?? '',
+        pv,
+        evaluation,
+      };
+      if (existingIndex >= 0) {
+        resultLines[existingIndex] = line;
+      } else {
+        resultLines.push(line);
+      }
+    };
+
+    const infoListener = (payload: string) => {
+      if (!payload.startsWith('info')) return;
+      collectLine(payload);
+    };
+
+    const removeInfoListener = onMessage(infoListener);
+
+    let removeBestMoveListener: (() => void) | null = null;
+    const analysisCompleted = new Promise<void>((resolve) => {
+      const handler = (payload: string) => {
+        if (!payload.startsWith('bestmove')) return;
+        const moveMatch = payload.match(/bestmove (\S+)/);
+        if (moveMatch) {
+          bestMove = moveMatch[1];
+        }
+        if (resultLines.length > 0) {
+          const bestLine = resultLines.reduce((acc, line) =>
+            line.multipv < acc.multipv ? line : acc,
+          resultLines[0]);
+          finalEvaluation = bestLine.evaluation;
+        }
+        resolve();
+      };
+      removeBestMoveListener = onMessage(handler);
+    });
+
+    sendCommand('ucinewgame');
+    sendCommand(`setoption name MultiPV value ${multiPv}`);
+    sendCommand(`position fen ${fen}`);
+    if (movetimeMs) {
+      sendCommand(`go movetime ${movetimeMs}`);
+    } else if (nodes) {
+      sendCommand(`go nodes ${nodes}`);
+    } else {
+      sendCommand('go depth 15');
+    }
+
+    await analysisCompleted;
+    removeInfoListener();
+    if (removeBestMoveListener) {
+      removeBestMoveListener();
+    }
+
+    return {
+      bestMove,
+      evaluation: finalEvaluation,
+      lines: resultLines.sort((a, b) => a.multipv - b.multipv),
+    };
+  };
+
+  return {
+    analysePosition: analysePositionInternal,
+    quit() {
+      sendCommand('quit');
+    },
+  };
+}

--- a/src/features/analysis/GameReviewPanel.tsx
+++ b/src/features/analysis/GameReviewPanel.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react';
+import { Badge, type BadgeProps } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { AnalysisTag, MoveAnalysis } from '@/services/analysisClient';
+import { useGameReview } from './hooks/useGameReview';
+
+type BadgeVariant = BadgeProps['variant'];
+
+const TAG_METADATA: Record<AnalysisTag, { icon: string; label: string; badgeVariant: BadgeVariant }> = {
+  ok: { icon: '✅', label: 'Meilleur', badgeVariant: 'default' },
+  inaccuracy: { icon: '🟡', label: 'Imprécision', badgeVariant: 'secondary' },
+  mistake: { icon: '🟠', label: 'Erreur', badgeVariant: 'secondary' },
+  blunder: { icon: '🔴', label: 'Gaffe', badgeVariant: 'destructive' },
+  brilliant: { icon: '💎', label: 'Brillant', badgeVariant: 'default' },
+  great: { icon: '⭐', label: 'Great move', badgeVariant: 'default' },
+};
+
+export interface GameReviewPanelProps {
+  pgn: string;
+  depth?: number;
+  multiPv?: number;
+  reviewMode?: 'auto' | 'local' | 'edge';
+  accuracyForElo?: number;
+  onShowBestMove?: (move: MoveAnalysis) => void;
+}
+
+export function GameReviewPanel({
+  pgn,
+  depth = 18,
+  multiPv = 3,
+  reviewMode = 'auto',
+  accuracyForElo,
+  onShowBestMove,
+}: GameReviewPanelProps) {
+  const { review, isPending, error, startReview } = useGameReview({
+    pgn,
+    depth,
+    multiPv,
+    reviewMode,
+    accuracyForElo,
+    autoStart: true,
+  });
+
+  const accuracy = review?.accuracy ?? 0;
+
+  const summaryChips = useMemo(() => {
+    if (!review?.summary || !('counts' in review.summary)) return [] as Array<{ tag: AnalysisTag; value: number }>;
+    const counts = review.summary.counts as Record<AnalysisTag, number>;
+    return (Object.keys(counts) as AnalysisTag[])
+      .filter((tag) => counts[tag] > 0)
+      .map((tag) => ({ tag, value: counts[tag] }));
+  }, [review?.summary]);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-lg font-semibold">Game review</CardTitle>
+          <Button size="sm" variant="outline" onClick={() => startReview()} disabled={isPending}>
+            Re-run
+          </Button>
+        </div>
+        {isPending ? (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-2 w-full" />
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive">{(error as Error).message}</p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>Precision</span>
+              <span className="font-semibold text-foreground">{accuracy.toFixed(1)}%</span>
+            </div>
+            <Progress value={accuracy} className="h-2" />
+            {summaryChips.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                {summaryChips.map(({ tag, value }) => {
+                  const meta = TAG_METADATA[tag];
+                  return (
+                    <Badge key={tag} variant={meta.badgeVariant} className="flex items-center gap-1">
+                      <span>{meta.icon}</span>
+                      <span className="uppercase text-xs font-medium">{meta.label}</span>
+                      <span className="text-xs font-semibold">{value}</span>
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </CardHeader>
+      <CardContent className="h-[420px]">
+        {isPending ? (
+          <div className="space-y-2">
+            {Array.from({ length: 12 }).map((_, index) => (
+              <Skeleton key={index} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : !review ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Submit a game to start the review.
+          </div>
+        ) : (
+          <ScrollArea className="h-full pr-2">
+            <ol className="space-y-3">
+              {review.moves.map((move) => {
+                const meta = TAG_METADATA[move.tag];
+                return (
+                  <li
+                    key={`${move.ply}-${move.san}`}
+                    className="rounded-lg border border-border bg-card px-3 py-2 shadow-sm transition hover:border-primary"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-3">
+                        <Badge variant={meta.badgeVariant} className="flex items-center gap-1 text-xs">
+                          <span>{meta.icon}</span>
+                          <span>{meta.label}</span>
+                        </Badge>
+                        <div>
+                          <p className="text-sm font-semibold text-foreground">
+                            #{move.ply} · {move.san}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Best: {move.bestMove} · Δ {(move.delta / 100).toFixed(2)} p
+                          </p>
+                        </div>
+                      </div>
+                      {onShowBestMove && (
+                        <Button size="sm" variant="ghost" onClick={() => onShowBestMove(move)}>
+                          Show best move
+                        </Button>
+                      )}
+                    </div>
+                    {move.principalVariation.length > 0 && (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        PV: {move.principalVariation.join(' ')}
+                      </p>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          </ScrollArea>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/analysis/hooks/useGameReview.ts
+++ b/src/features/analysis/hooks/useGameReview.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { analysisClient, type AnalyseGameRequest, type AnalyseGameResponse } from '@/services/analysisClient';
+
+export interface UseGameReviewOptions extends AnalyseGameRequest {
+  autoStart?: boolean;
+}
+
+export interface UseGameReviewResult {
+  review: AnalyseGameResponse | null;
+  isPending: boolean;
+  error: unknown;
+  startReview: (override?: Partial<AnalyseGameRequest>) => void;
+  reset: () => void;
+}
+
+export function useGameReview(options: UseGameReviewOptions): UseGameReviewResult {
+  const request = useMemo<AnalyseGameRequest>(
+    () => ({
+      pgn: options.pgn,
+      depth: options.depth,
+      multiPv: options.multiPv,
+      reviewMode: options.reviewMode,
+      accuracyForElo: options.accuracyForElo,
+    }),
+    [options.accuracyForElo, options.depth, options.multiPv, options.pgn, options.reviewMode],
+  );
+
+  const { mutate, data, error, isPending, reset } = useMutation({
+    mutationFn: (payload: AnalyseGameRequest) => analysisClient.analyseGame(payload),
+  });
+
+  const startReview = useCallback(
+    (override?: Partial<AnalyseGameRequest>) => {
+      mutate({ ...request, ...override });
+    },
+    [mutate, request],
+  );
+
+  useEffect(() => {
+    if (options.autoStart && request.pgn) {
+      startReview();
+    }
+  }, [options.autoStart, request, startReview]);
+
+  return {
+    review: data ?? null,
+    isPending,
+    error,
+    startReview,
+    reset,
+  };
+}

--- a/src/services/analysisClient.ts
+++ b/src/services/analysisClient.ts
@@ -1,0 +1,318 @@
+import { Chess } from 'chess.js';
+import type {
+  AnalysePositionParams,
+  AnalysePositionResult,
+  EngineHandle,
+} from '@/engine/stockfishClient';
+import { initEngine } from '@/engine/stockfishClient';
+
+export interface AnalyseGameRequest {
+  pgn: string;
+  depth?: number;
+  multiPv?: number;
+  accuracyForElo?: number;
+  reviewMode?: 'auto' | 'local' | 'edge';
+}
+
+export interface MoveAnalysis {
+  ply: number;
+  san: string;
+  fenBefore: string;
+  fenAfter: string;
+  evaluationBefore: number;
+  evaluationAfter: number;
+  bestMove: string;
+  principalVariation: string[];
+  delta: number;
+  tag: AnalysisTag;
+}
+
+export type AnalysisTag =
+  | 'ok'
+  | 'inaccuracy'
+  | 'mistake'
+  | 'blunder'
+  | 'brilliant'
+  | 'great';
+
+export interface AnalyseGameResponse {
+  moves: MoveAnalysis[];
+  accuracy: number;
+  summary: Record<string, unknown>;
+  engine: string;
+  depth: number;
+}
+
+export interface AnalysisClientOptions {
+  wasmUrl?: string;
+  edgeFunctionUrl?: string;
+  localMoveTimeMs?: number;
+  shortGamePlyThreshold?: number;
+}
+
+const DEFAULT_OPTIONS: Required<AnalysisClientOptions> = {
+  wasmUrl: '/engines/stockfish.wasm',
+  edgeFunctionUrl: '/functions/v1/analysis',
+  localMoveTimeMs: 120,
+  shortGamePlyThreshold: 80,
+};
+
+type Thresholds = {
+  ok: number;
+  inaccuracy: number;
+  mistake: number;
+  blunder: number;
+};
+
+const LOCAL_THRESHOLDS: { default: Thresholds; brackets: Array<{ maxElo: number; thresholds: Thresholds }> } = {
+  default: { ok: 0.15, inaccuracy: 0.6, mistake: 1.8, blunder: 3.5 },
+  brackets: [
+    { maxElo: 1200, thresholds: { ok: 0.2, inaccuracy: 0.8, mistake: 2.2, blunder: 4.0 } },
+    { maxElo: 1600, thresholds: { ok: 0.18, inaccuracy: 0.7, mistake: 2.0, blunder: 3.8 } },
+    { maxElo: 2000, thresholds: { ok: 0.16, inaccuracy: 0.65, mistake: 1.9, blunder: 3.6 } },
+  ],
+};
+
+type VerboseMove = {
+  color: 'w' | 'b';
+  san: string;
+  from: string;
+  to: string;
+  promotion?: string;
+};
+
+function resolveThresholds(elo?: number): Thresholds {
+  if (!elo) return LOCAL_THRESHOLDS.default;
+  for (const bracket of LOCAL_THRESHOLDS.brackets) {
+    if (elo <= bracket.maxElo) {
+      return bracket.thresholds;
+    }
+  }
+  return LOCAL_THRESHOLDS.default;
+}
+
+function classifyDelta(deltaPawns: number, thresholds: Thresholds): AnalysisTag {
+  const absDelta = Math.abs(deltaPawns);
+  if (absDelta < thresholds.ok) return 'ok';
+  if (absDelta < thresholds.inaccuracy) return 'inaccuracy';
+  if (absDelta < thresholds.mistake) return 'mistake';
+  if (absDelta < thresholds.blunder) return 'blunder';
+  return 'blunder';
+}
+
+function buildBoard(fen: string): Chess {
+  const board = new Chess();
+  const loaded = board.load(fen);
+  if (!loaded) {
+    board.reset();
+  }
+  return board;
+}
+
+function findMove(board: Chess, uci: string): VerboseMove | undefined {
+  const moves = board.moves({ verbose: true }) as VerboseMove[];
+  return moves.find((move) => {
+    const promotion = move.promotion ? move.promotion : '';
+    return `${move.from}${move.to}${promotion}` === uci;
+  });
+}
+
+function applyMove(board: Chess, uci: string) {
+  const move = findMove(board, uci);
+  if (move) {
+    board.move({ from: move.from, to: move.to, promotion: move.promotion });
+  } else {
+    board.move(uci, { sloppy: true });
+  }
+}
+
+function pvToSanSequence(fen: string, pv: string[]): string[] {
+  const board = buildBoard(fen);
+  const sequence: string[] = [];
+  for (const uci of pv) {
+    const move = findMove(board, uci);
+    sequence.push(move?.san ?? uci);
+    applyMove(board, uci);
+  }
+  return sequence;
+}
+
+export class AnalysisClient {
+  private options: Required<AnalysisClientOptions>;
+
+  private enginePromise: Promise<EngineHandle> | null = null;
+
+  constructor(options?: AnalysisClientOptions) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  async analyseGame(request: AnalyseGameRequest): Promise<AnalyseGameResponse> {
+    const mode = this.resolveMode(request);
+    if (mode === 'local') {
+      return this.analyseGameLocally(request);
+    }
+    return this.analyseGameViaEdge(request);
+  }
+
+  private resolveMode(request: AnalyseGameRequest): 'local' | 'edge' {
+    if (request.reviewMode && request.reviewMode !== 'auto') {
+      return request.reviewMode;
+    }
+    const chess = new Chess();
+    chess.load_pgn(request.pgn);
+    const plyCount = chess.history({ verbose: true }).length;
+    return plyCount <= this.options.shortGamePlyThreshold ? 'local' : 'edge';
+  }
+
+  private async getEngine(): Promise<EngineHandle> {
+    if (!this.enginePromise) {
+      this.enginePromise = initEngine(this.options.wasmUrl);
+    }
+    return this.enginePromise;
+  }
+
+  private async analyseGameLocally(request: AnalyseGameRequest): Promise<AnalyseGameResponse> {
+    const chess = new Chess();
+    if (!chess.load_pgn(request.pgn)) {
+      throw new Error('Invalid PGN provided for analysis');
+    }
+    const engine = await this.getEngine();
+    const verboseMoves = chess.history({ verbose: true }) as VerboseMove[];
+    const headers = chess.header();
+    const initialFen = headers.SetUp === '1' && headers.FEN ? (headers.FEN as string) : undefined;
+    const analysisBoard = new Chess();
+    if (initialFen) {
+      analysisBoard.load(initialFen);
+    } else {
+      analysisBoard.reset();
+    }
+
+    const analyses: MoveAnalysis[] = [];
+    let ply = 1;
+    for (const move of verboseMoves) {
+      const beforeFen = analysisBoard.fen();
+      const povSign = move.color === 'w' ? 1 : -1;
+
+      const baseAnalysis = await this.analysePosition(engine, {
+        fen: beforeFen,
+        movetimeMs: this.options.localMoveTimeMs,
+        multiPv: request.multiPv ?? 3,
+      });
+
+      analysisBoard.move({ from: move.from, to: move.to, promotion: move.promotion });
+      const afterFen = analysisBoard.fen();
+
+      const followupAnalysis = await this.analysePosition(engine, {
+        fen: afterFen,
+        movetimeMs: this.options.localMoveTimeMs,
+        multiPv: request.multiPv ?? 1,
+      });
+
+      const evaluationBefore = this.evaluationToCentipawns(baseAnalysis.evaluation, povSign);
+      const evaluationAfter = this.evaluationToCentipawns(followupAnalysis.evaluation, povSign);
+      const bestLine = baseAnalysis.lines.find((line) => line.multipv === 1) ?? baseAnalysis.lines[0];
+      const principalVariation = bestLine ? pvToSanSequence(beforeFen, bestLine.pv) : [];
+      let bestMove = baseAnalysis.bestMove;
+      if (bestLine) {
+        bestMove = principalVariation[0] ?? findMove(buildBoard(beforeFen), bestLine.pv[0])?.san ?? bestLine.pv[0];
+      } else if (bestMove) {
+        bestMove = findMove(buildBoard(beforeFen), bestMove)?.san ?? bestMove;
+      }
+      const delta = evaluationAfter - evaluationBefore;
+      const tag = classifyDelta(delta / 100, resolveThresholds(request.accuracyForElo));
+
+      analyses.push({
+        ply,
+        san: move.san,
+        fenBefore: beforeFen,
+        fenAfter: afterFen,
+        evaluationBefore,
+        evaluationAfter,
+        bestMove,
+        principalVariation,
+        delta,
+        tag,
+      });
+      ply += 1;
+    }
+
+    return {
+      moves: analyses,
+      accuracy: this.estimateAccuracy(analyses),
+      summary: {},
+      engine: 'stockfish-wasm',
+      depth: 0,
+    };
+  }
+
+  private async analyseGameViaEdge(request: AnalyseGameRequest): Promise<AnalyseGameResponse> {
+    const response = await fetch(this.options.edgeFunctionUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Edge analysis failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const moves = (payload.moves ?? []) as Array<{
+      ply: number;
+      san: string;
+      fen_before: string;
+      fen_after: string;
+      eval_cp_before: number;
+      eval_cp_after: number;
+      best_move: string;
+      pv: string[];
+      delta_cp: number;
+      tag: AnalysisTag;
+    }>;
+
+    return {
+      moves: moves.map((move) => ({
+        ply: move.ply,
+        san: move.san,
+        fenBefore: move.fen_before,
+        fenAfter: move.fen_after,
+        evaluationBefore: move.eval_cp_before,
+        evaluationAfter: move.eval_cp_after,
+        bestMove: move.best_move,
+        principalVariation: move.pv,
+        delta: move.delta_cp,
+        tag: move.tag,
+      })),
+      accuracy: payload.accuracy ?? 0,
+      summary: payload.summary ?? {},
+      engine: payload.engine ?? 'stockfish16',
+      depth: payload.depth ?? request.depth ?? 0,
+    };
+  }
+
+  private async analysePosition(
+    engine: EngineHandle,
+    params: AnalysePositionParams,
+  ): Promise<AnalysePositionResult> {
+    return engine.analysePosition(params);
+  }
+
+  private evaluationToCentipawns(evaluation: AnalysePositionResult['evaluation'], povSign: number): number {
+    if (evaluation.type === 'mate') {
+      const mateScore = evaluation.value > 0 ? 100000 : -100000;
+      return mateScore * povSign;
+    }
+    return evaluation.value * povSign;
+  }
+
+  private estimateAccuracy(moves: MoveAnalysis[]): number {
+    if (moves.length === 0) return 100;
+    const penalties = moves
+      .map((move) => Math.min(1, Math.abs(move.delta) / 300))
+      .reduce((acc, penalty) => acc + penalty, 0);
+    const accuracy = Math.max(0, 100 - (penalties / moves.length) * 100);
+    return Number(accuracy.toFixed(2));
+  }
+}
+
+export const analysisClient = new AnalysisClient();

--- a/supabase/functions/analysis/index.ts
+++ b/supabase/functions/analysis/index.ts
@@ -1,0 +1,419 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { Chess } from 'npm:chess.js';
+import { TextLineStream } from 'https://deno.land/std@0.224.0/streams/text_line_stream.ts';
+import { tagMove, type AnalysisTag, type MultipvLine as TaggerMultipvLine } from './tagger.ts';
+
+interface AnalysisRequest {
+  pgn: string;
+  depth?: number;
+  multiPv?: number;
+  accuracyForElo?: number;
+}
+
+interface EngineEvaluation {
+  type: 'cp' | 'mate';
+  value: number;
+}
+
+interface StockfishLine {
+  multipv: number;
+  move: string;
+  pv: string[];
+  evaluation: EngineEvaluation;
+}
+
+interface PositionAnalysis {
+  bestMove: string;
+  evaluation: EngineEvaluation;
+  lines: StockfishLine[];
+}
+
+interface MovePayload {
+  ply: number;
+  san: string;
+  fen_before: string;
+  fen_after: string;
+  eval_cp_before: number;
+  eval_cp_after: number;
+  eval_cp_best: number;
+  best_move: string;
+  pv: string[];
+  delta_cp: number;
+  tag: AnalysisTag;
+}
+
+interface AnalysisResponse {
+  engine: string;
+  depth: number;
+  accuracy: number;
+  summary: Record<string, unknown>;
+  moves: MovePayload[];
+}
+
+class StockfishProcess {
+  private process: Deno.ChildProcess;
+
+  private stdoutQueue: string[] = [];
+
+  private waiters: ((line: string) => void)[] = [];
+
+  private closed = false;
+
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+
+  private encoder = new TextEncoder();
+
+  constructor(private depth: number, private multiPv: number) {
+    const binary = Deno.env.get('STOCKFISH_PATH') ?? './stockfish';
+    const command = new Deno.Command(binary, {
+      stdin: 'piped',
+      stdout: 'piped',
+      stderr: 'null',
+    });
+
+    this.process = command.spawn();
+    this.writer = this.process.stdin.getWriter();
+    const reader = this.process.stdout
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TextLineStream());
+    this.consume(reader);
+  }
+
+  private async consume(stream: ReadableStream<string>) {
+    for await (const line of stream) {
+      if (this.waiters.length > 0) {
+        const waiter = this.waiters.shift();
+        waiter?.(line);
+      } else {
+        this.stdoutQueue.push(line);
+      }
+    }
+    this.closed = true;
+  }
+
+  private async readLine(): Promise<string> {
+    if (this.stdoutQueue.length > 0) {
+      return this.stdoutQueue.shift() as string;
+    }
+    if (this.closed) {
+      throw new Error('Stockfish process terminated unexpectedly');
+    }
+    return new Promise<string>((resolve) => this.waiters.push(resolve));
+  }
+
+  private async write(command: string) {
+    await this.writer.write(this.encoder.encode(`${command}\n`));
+  }
+
+  async initialize() {
+    await this.write('uci');
+    let line = '';
+    do {
+      line = await this.readLine();
+    } while (!line.includes('uciok'));
+    await this.write(`setoption name MultiPV value ${this.multiPv}`);
+    await this.write('isready');
+    do {
+      line = await this.readLine();
+    } while (!line.includes('readyok'));
+  }
+
+  async analysePosition(fen: string): Promise<PositionAnalysis> {
+    await this.write('ucinewgame');
+    await this.write(`position fen ${fen}`);
+    await this.write(`go depth ${this.depth}`);
+
+    const lines: StockfishLine[] = [];
+    let bestMove = '';
+    let evaluation: EngineEvaluation = { type: 'cp', value: 0 };
+
+    while (true) {
+      const payload = await this.readLine();
+      if (payload.startsWith('info') && payload.includes('multipv')) {
+        const parsed = parseInfoLine(payload);
+        if (parsed) {
+          const existingIndex = lines.findIndex((line) => line.multipv === parsed.line.multipv);
+          if (existingIndex >= 0) {
+            lines[existingIndex] = parsed.line;
+          } else {
+            lines.push(parsed.line);
+          }
+          if (parsed.line.multipv === 1) {
+            evaluation = parsed.evaluation;
+          }
+        }
+      }
+      if (payload.startsWith('bestmove')) {
+        const match = payload.match(/bestmove (\S+)/);
+        if (match) {
+          bestMove = match[1];
+        }
+        break;
+      }
+    }
+
+    return {
+      bestMove,
+      evaluation,
+      lines: lines.sort((a, b) => a.multipv - b.multipv),
+    };
+  }
+
+  async close() {
+    try {
+      await this.write('quit');
+      await this.writer.close();
+      await this.process.status;
+    } catch (_) {
+      // ignore errors on shutdown
+    }
+  }
+}
+
+function parseInfoLine(payload: string):
+  | { line: StockfishLine; evaluation: EngineEvaluation }
+  | null {
+  const multipvMatch = payload.match(/ multipv (\d+)/);
+  if (!multipvMatch) return null;
+  const multipv = Number.parseInt(multipvMatch[1], 10);
+  const evaluation = extractEvaluation(payload);
+  if (!evaluation) return null;
+  const pvMatch = payload.match(/ pv (.*)$/);
+  if (!pvMatch) return null;
+  const pv = pvMatch[1].trim().split(/\s+/);
+  return {
+    evaluation,
+    line: {
+      multipv,
+      move: pv[0],
+      pv,
+      evaluation,
+    },
+  };
+}
+
+function extractEvaluation(payload: string): EngineEvaluation | null {
+  const mateMatch = payload.match(/ mate (-?\d+)/);
+  if (mateMatch) {
+    return { type: 'mate', value: Number.parseInt(mateMatch[1], 10) };
+  }
+  const cpMatch = payload.match(/ cp (-?\d+)/);
+  if (cpMatch) {
+    return { type: 'cp', value: Number.parseInt(cpMatch[1], 10) };
+  }
+  return null;
+}
+
+function convertEvaluationToCentipawns(evaluation: EngineEvaluation, pov: 1 | -1): number {
+  if (evaluation.type === 'mate') {
+    const mateScore = evaluation.value > 0 ? 100000 : -100000;
+    return mateScore * pov;
+  }
+  return evaluation.value * pov;
+}
+
+type VerboseMove = {
+  color: 'w' | 'b';
+  san: string;
+  from: string;
+  to: string;
+  promotion?: string;
+};
+
+function findMove(chess: Chess, uciMove: string): VerboseMove | undefined {
+  const candidates = chess.moves({ verbose: true }) as VerboseMove[];
+  return candidates.find((move) => {
+    const promotion = move.promotion ? move.promotion : '';
+    return `${move.from}${move.to}${promotion}` === uciMove;
+  });
+}
+
+function uciToSan(chess: Chess, uciMove: string): string | undefined {
+  return findMove(chess, uciMove)?.san;
+}
+
+function applyMove(chess: Chess, uciMove: string) {
+  const move = findMove(chess, uciMove);
+  if (move) {
+    chess.move({ from: move.from, to: move.to, promotion: move.promotion });
+  } else {
+    chess.move(uciMove, { sloppy: true });
+  }
+}
+
+function buildChess(fen: string): Chess {
+  const instance = new Chess();
+  instance.load(fen);
+  return instance;
+}
+
+function pvToSanSequence(fen: string, pv: string[]): string[] {
+  const board = buildChess(fen);
+  const sequence: string[] = [];
+  for (const uci of pv) {
+    const san = uciToSan(board, uci) ?? uci;
+    sequence.push(san);
+    applyMove(board, uci);
+  }
+  return sequence;
+}
+
+async function runAnalysis(request: AnalysisRequest): Promise<AnalysisResponse> {
+  const depth = request.depth ?? 20;
+  const multiPv = request.multiPv ?? 3;
+  const chess = new Chess();
+  if (!chess.load_pgn(request.pgn)) {
+    throw new Error('Invalid PGN payload');
+  }
+
+  const engine = new StockfishProcess(depth, multiPv);
+  await engine.initialize();
+
+  const movesVerbose = chess.history({ verbose: true }) as VerboseMove[];
+  const headers = chess.header();
+  const initialFen = headers.SetUp === '1' && headers.FEN ? (headers.FEN as string) : undefined;
+  const analysisBoard = new Chess();
+  if (initialFen) {
+    analysisBoard.load(initialFen);
+  } else {
+    analysisBoard.reset();
+  }
+
+  const analyses: MovePayload[] = [];
+  let ply = 1;
+
+  for (const move of movesVerbose) {
+    const beforeFen = analysisBoard.fen();
+    const color = move.color as 'w' | 'b';
+    const pov: 1 | -1 = color === 'w' ? 1 : -1;
+
+    const beforeAnalysis = await engine.analysePosition(beforeFen);
+    const bestLine = beforeAnalysis.lines[0];
+    const evaluationBest = convertEvaluationToCentipawns(beforeAnalysis.evaluation, pov);
+
+    const multipvLines: TaggerMultipvLine[] = beforeAnalysis.lines.map((line) => {
+      const san = uciToSan(analysisBoard, line.pv[0]);
+      return {
+        multipv: line.multipv,
+        move: san ?? line.pv[0],
+        pv: line.pv,
+        evaluation: convertEvaluationToCentipawns(line.evaluation, pov),
+      };
+    });
+
+    analysisBoard.move({ from: move.from, to: move.to, promotion: move.promotion });
+    const afterFen = analysisBoard.fen();
+
+    const afterAnalysis = await engine.analysePosition(afterFen);
+    const evaluationAfter = convertEvaluationToCentipawns(afterAnalysis.evaluation, pov);
+    const afterBestLine = afterAnalysis.lines[0];
+
+    if (!multipvLines.some((line) => line.move === move.san)) {
+      const actualPv = [
+        move.san,
+        ...(afterBestLine ? pvToSanSequence(afterFen, afterBestLine.pv) : []),
+      ];
+      multipvLines.push({
+        multipv: Number.MAX_SAFE_INTEGER,
+        move: move.san,
+        pv: actualPv,
+        evaluation: evaluationAfter,
+      });
+    }
+
+    const bestMoveUci = bestLine ? bestLine.pv[0] : beforeAnalysis.bestMove;
+    const bestMoveSan = bestMoveUci
+      ? ((): string => {
+          const board = buildChess(beforeFen);
+          return uciToSan(board, bestMoveUci) ?? bestMoveUci;
+        })()
+      : '';
+    const pvSan = bestLine ? pvToSanSequence(beforeFen, bestLine.pv) : [];
+
+    const delta = evaluationAfter - evaluationBest;
+    const tag = tagMove(
+      {
+        ply,
+        san: move.san,
+        color,
+        fenBefore: beforeFen,
+        fenAfter: afterFen,
+        evaluationAfterPlayed: evaluationAfter,
+        evaluationBest,
+        multipvLines,
+      },
+      { playerElo: request.accuracyForElo },
+    );
+
+    analyses.push({
+      ply,
+      san: move.san,
+      fen_before: beforeFen,
+      fen_after: afterFen,
+      eval_cp_before: evaluationBest,
+      eval_cp_after: evaluationAfter,
+      eval_cp_best: evaluationBest,
+      best_move: bestMoveSan ?? beforeAnalysis.bestMove,
+      pv: pvSan,
+      delta_cp: delta,
+      tag,
+    });
+
+    ply += 1;
+  }
+
+  await engine.close();
+
+  const accuracy = calculateAccuracy(analyses);
+
+  return {
+    engine: 'stockfish16',
+    depth,
+    accuracy,
+    summary: buildSummary(analyses),
+    moves: analyses,
+  };
+}
+
+function calculateAccuracy(moves: MovePayload[]): number {
+  if (moves.length === 0) return 100;
+  const penalties = moves
+    .map((move) => Math.min(1, Math.abs(move.delta_cp) / 300))
+    .reduce((acc, cur) => acc + cur, 0);
+  const accuracy = Math.max(0, 100 - (penalties / moves.length) * 100);
+  return Number(accuracy.toFixed(2));
+}
+
+function buildSummary(moves: MovePayload[]): Record<string, unknown> {
+  const buckets: Record<AnalysisTag, number> = {
+    ok: 0,
+    inaccuracy: 0,
+    mistake: 0,
+    blunder: 0,
+    brilliant: 0,
+    great: 0,
+  };
+  for (const move of moves) {
+    buckets[move.tag] += 1;
+  }
+  return {
+    counts: buckets,
+  };
+}
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+  try {
+    const body = (await req.json()) as AnalysisRequest;
+    const result = await runAnalysis(body);
+    return Response.json(result);
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/analysis/tagger.ts
+++ b/supabase/functions/analysis/tagger.ts
@@ -1,0 +1,139 @@
+import { Chess } from 'npm:chess.js';
+import thresholdsConfig from './thresholds.json' assert { type: 'json' };
+
+export type AnalysisTag =
+  | 'ok'
+  | 'inaccuracy'
+  | 'mistake'
+  | 'blunder'
+  | 'brilliant'
+  | 'great';
+
+export interface MultipvLine {
+  move: string;
+  pv: string[];
+  evaluation: number;
+  multipv: number;
+}
+
+export interface TaggableMove {
+  ply: number;
+  san: string;
+  color: 'w' | 'b';
+  fenBefore: string;
+  fenAfter: string;
+  evaluationAfterPlayed: number;
+  evaluationBest: number;
+  multipvLines: MultipvLine[];
+}
+
+export interface TaggingOptions {
+  playerElo?: number;
+}
+
+interface Thresholds {
+  ok: number;
+  inaccuracy: number;
+  mistake: number;
+  blunder: number;
+}
+
+const PIECE_VALUES: Record<string, number> = {
+  p: 1,
+  n: 3,
+  b: 3,
+  r: 5,
+  q: 9,
+  k: 0,
+};
+
+function getThresholds(elo?: number): Thresholds {
+  if (!elo) {
+    return thresholdsConfig.default as Thresholds;
+  }
+
+  for (const bracket of thresholdsConfig.brackets ?? []) {
+    if (typeof bracket.maxElo === 'number' && elo <= bracket.maxElo) {
+      return bracket.thresholds as Thresholds;
+    }
+  }
+
+  return thresholdsConfig.default as Thresholds;
+}
+
+function classifyDelta(delta: number, thresholds: Thresholds): AnalysisTag {
+  const absDelta = Math.abs(delta) / 100;
+  if (absDelta < thresholds.ok) return 'ok';
+  if (absDelta < thresholds.inaccuracy) return 'inaccuracy';
+  if (absDelta < thresholds.mistake) return 'mistake';
+  return 'blunder';
+}
+
+function evaluateMaterial(fen: string, color: 'w' | 'b'): number {
+  const chess = new Chess(fen);
+  return chess
+    .board()
+    .flat()
+    .reduce((score, piece) => {
+      if (!piece || piece.color !== color) return score;
+      return score + (PIECE_VALUES[piece.type] ?? 0);
+    }, 0);
+}
+
+function findLineForMove(lines: MultipvLine[], move: string): MultipvLine | undefined {
+  return lines.find((line) => line.move === move);
+}
+
+function detectSacrifice(fenBefore: string, fenAfter: string, color: 'w' | 'b'): boolean {
+  const beforeMaterial = evaluateMaterial(fenBefore, color);
+  const afterMaterial = evaluateMaterial(fenAfter, color);
+  return beforeMaterial - afterMaterial >= 4; // sacrifice of major piece
+}
+
+export function tagMove(move: TaggableMove, options: TaggingOptions = {}): AnalysisTag {
+  const thresholds = getThresholds(options.playerElo);
+  const delta = move.evaluationAfterPlayed - move.evaluationBest;
+  const baseTag = classifyDelta(delta, thresholds);
+
+  if (baseTag === 'ok' || baseTag === 'inaccuracy') {
+    const playedLine = findLineForMove(move.multipvLines, move.san);
+    if (playedLine && playedLine.multipv <= 2) {
+      const sacrifice = detectSacrifice(move.fenBefore, move.fenAfter, move.color);
+      if (sacrifice && Math.abs(delta) / 100 <= thresholds.ok) {
+        const nextBest = move.multipvLines
+          .filter((line) => line.multipv !== playedLine.multipv)
+          .sort((a, b) => a.multipv - b.multipv)[0];
+        if (!nextBest || playedLine.evaluation - nextBest.evaluation > thresholds.ok * 100) {
+          return 'brilliant';
+        }
+      }
+    }
+  }
+
+  if (baseTag !== 'blunder') {
+    const bestLine = move.multipvLines.find((line) => line.multipv === 1);
+    const playedLine = findLineForMove(move.multipvLines, move.san);
+    if (bestLine && playedLine) {
+      const isOnlyMove = move.multipvLines.every((line) =>
+        line.multipv === playedLine.multipv || playedLine.evaluation - line.evaluation > thresholds.ok * 100,
+      );
+      const flipsEvaluation = Math.sign(move.evaluationBest) !== Math.sign(move.evaluationAfterPlayed);
+      if ((isOnlyMove || flipsEvaluation) && Math.abs(delta) / 100 <= thresholds.ok) {
+        return 'great';
+      }
+    }
+  }
+
+  if (
+    baseTag === 'blunder' &&
+    Math.sign(move.evaluationBest) !== Math.sign(move.evaluationAfterPlayed)
+  ) {
+    return 'blunder';
+  }
+
+  return baseTag;
+}
+
+export function tagMoves(moves: TaggableMove[], options: TaggingOptions = {}): AnalysisTag[] {
+  return moves.map((move) => tagMove(move, options));
+}

--- a/supabase/functions/analysis/thresholds.json
+++ b/supabase/functions/analysis/thresholds.json
@@ -1,0 +1,37 @@
+{
+  "default": {
+    "ok": 0.15,
+    "inaccuracy": 0.6,
+    "mistake": 1.8,
+    "blunder": 3.5
+  },
+  "brackets": [
+    {
+      "maxElo": 1200,
+      "thresholds": {
+        "ok": 0.2,
+        "inaccuracy": 0.8,
+        "mistake": 2.2,
+        "blunder": 4.0
+      }
+    },
+    {
+      "maxElo": 1600,
+      "thresholds": {
+        "ok": 0.18,
+        "inaccuracy": 0.7,
+        "mistake": 2.0,
+        "blunder": 3.8
+      }
+    },
+    {
+      "maxElo": 2000,
+      "thresholds": {
+        "ok": 0.16,
+        "inaccuracy": 0.65,
+        "mistake": 1.9,
+        "blunder": 3.6
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a browser WASM stockfish client with helpers to parse principal variations
- introduce a frontend analysis service, hook, and review panel UI that switches between local WASM and edge analysis
- implement a Supabase Edge Function that drives Stockfish, tags moves, and returns accuracy metrics with configurable thresholds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcaf6a3d608323822dd3211b48cae2