### PR TITLE
Add rule-based chess coach explanations and pattern detection

### DIFF
--- a/src/features/analysis/GameReviewPanel.tsx
+++ b/src/features/analysis/GameReviewPanel.tsx
@@ -6,6 +6,8 @@ import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { AnalysisTag, MoveAnalysis } from '@/services/analysisClient';
+import type { CoachTone } from '@/lib/analysis/coachMessages';
+import type { PatternId } from '@/lib/analysis/patterns';
 import { useGameReview } from './hooks/useGameReview';
 
 type BadgeVariant = BadgeProps['variant'];
@@ -17,6 +19,22 @@ const TAG_METADATA: Record<AnalysisTag, { icon: string; label: string; badgeVari
   blunder: { icon: '🔴', label: 'Gaffe', badgeVariant: 'destructive' },
   brilliant: { icon: '💎', label: 'Brillant', badgeVariant: 'default' },
   great: { icon: '⭐', label: 'Great move', badgeVariant: 'default' },
+};
+
+const COACH_TONE_COLORS: Record<CoachTone, string> = {
+  positive: 'text-emerald-600 dark:text-emerald-400',
+  info: 'text-foreground',
+  warning: 'text-amber-600 dark:text-amber-400',
+  critical: 'text-destructive',
+};
+
+const PATTERN_LABELS: Record<PatternId, { icon: string; label: string }> = {
+  'hanging-piece': { icon: '⚠️', label: 'Pièce non protégée' },
+  'material-drop': { icon: '💸', label: 'Matériel perdu' },
+  'fork-threat': { icon: '🔱', label: 'Menace de fourchette' },
+  pin: { icon: '📍', label: 'Clouage' },
+  'missed-mate': { icon: '♛', label: 'Mat forcé manqué' },
+  'mate-threat': { icon: '☠️', label: 'Mat subi en vue' },
 };
 
 export interface GameReviewPanelProps {
@@ -131,11 +149,37 @@ export function GameReviewPanel({
                           </p>
                         </div>
                       </div>
-                      {onShowBestMove && (
-                        <Button size="sm" variant="ghost" onClick={() => onShowBestMove(move)}>
-                          Show best move
-                        </Button>
-                      )}
+                    </div>
+                    <div className="mt-3 rounded-md border border-dashed border-border/70 bg-muted/40 p-3">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="space-y-2">
+                          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            Pourquoi ?
+                          </p>
+                          <p className={`text-sm leading-snug ${COACH_TONE_COLORS[move.coach.tone]}`}>
+                            {move.coach.fr}
+                          </p>
+                          {move.patterns.length > 0 && (
+                            <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+                              {move.patterns.map((pattern, index) => {
+                                const label = PATTERN_LABELS[pattern.id];
+                                if (!label) return null;
+                                return (
+                                  <Badge key={`${pattern.id}-${index}`} variant="outline" className="flex items-center gap-1">
+                                    <span>{label.icon}</span>
+                                    <span>{label.label}</span>
+                                  </Badge>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                        {onShowBestMove && (
+                          <Button size="sm" variant="outline" onClick={() => onShowBestMove(move)}>
+                            Voir la ligne
+                          </Button>
+                        )}
+                      </div>
                     </div>
                     {move.principalVariation.length > 0 && (
                       <p className="mt-2 text-xs text-muted-foreground">

--- a/src/lib/analysis/coachMessages.ts
+++ b/src/lib/analysis/coachMessages.ts
@@ -1,0 +1,229 @@
+import type { DetectedPattern, PatternId, PatternSeverity } from '@/lib/analysis/patterns';
+
+export type CoachLanguage = 'fr' | 'en';
+
+export type CoachTone = 'positive' | 'info' | 'warning' | 'critical';
+
+export interface CoachMessage {
+  fr: string;
+  en: string;
+  tone: CoachTone;
+  patterns: DetectedPattern[];
+}
+
+export type AnalysisTag =
+  | 'ok'
+  | 'inaccuracy'
+  | 'mistake'
+  | 'blunder'
+  | 'brilliant'
+  | 'great';
+
+export interface CoachMessageContext {
+  tag: AnalysisTag;
+  delta: number;
+  san: string;
+  bestMove: string;
+  patterns: DetectedPattern[];
+}
+
+const PIECE_NAMES: Record<CoachLanguage, Record<string, string>> = {
+  fr: {
+    p: 'pion',
+    n: 'cavalier',
+    b: 'fou',
+    r: 'tour',
+    q: 'dame',
+    k: 'roi',
+  },
+  en: {
+    p: 'pawn',
+    n: 'knight',
+    b: 'bishop',
+    r: 'rook',
+    q: 'queen',
+    k: 'king',
+  },
+};
+
+const SQUARE_WORD: Record<CoachLanguage, string> = {
+  fr: 'case',
+  en: 'square',
+};
+
+function severityToTone(severity: PatternSeverity): CoachTone {
+  switch (severity) {
+    case 'critical':
+      return 'critical';
+    case 'warning':
+      return 'warning';
+    default:
+      return 'info';
+  }
+}
+
+function describeSquare(square: unknown, language: CoachLanguage): string {
+  return typeof square === 'string' ? `${SQUARE_WORD[language]} ${square}` : SQUARE_WORD[language];
+}
+
+function pieceLabel(piece: unknown, language: CoachLanguage): string {
+  if (typeof piece !== 'string') return language === 'fr' ? 'pièce' : 'piece';
+  const lower = piece.toLowerCase();
+  return PIECE_NAMES[language][lower] ?? (language === 'fr' ? 'pièce' : 'piece');
+}
+
+function listTargets(targets: unknown, language: CoachLanguage): string {
+  if (!Array.isArray(targets) || targets.length === 0) {
+    return language === 'fr' ? 'plusieurs pièces' : 'multiple pieces';
+  }
+  const formatted = targets
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const square = typeof (entry as { square?: unknown }).square === 'string'
+        ? (entry as { square: string }).square
+        : null;
+      const piece = (entry as { piece?: unknown }).piece;
+      if (!square) return null;
+      const label = pieceLabel(piece, language);
+      return language === 'fr' ? `${label} en ${square}` : `${square} ${label}`;
+    })
+    .filter((item): item is string => Boolean(item));
+  if (formatted.length === 0) {
+    return language === 'fr' ? 'plusieurs pièces' : 'multiple pieces';
+  }
+  if (formatted.length === 1) return formatted[0];
+  const last = formatted.pop() as string;
+  const joiner = language === 'fr' ? ' et ' : ' and ';
+  return `${formatted.join(language === 'fr' ? ', ' : ', ')}${joiner}${last}`;
+}
+
+function describePattern(pattern: DetectedPattern, language: CoachLanguage): string {
+  const data = pattern.data ?? {};
+  switch (pattern.id) {
+    case 'hanging-piece': {
+      const square = describeSquare((data as { square?: unknown }).square, language);
+      const piece = pieceLabel((data as { piece?: unknown }).piece, language);
+      return language === 'fr'
+        ? `Ta ${piece} sur ${square} n'est pas défendue : protège-la vite.`
+        : `Your ${piece} on that ${square} is hanging—defend it immediately.`;
+    }
+    case 'material-drop': {
+      const lost = typeof (data as { lost?: unknown }).lost === 'number'
+        ? Number.parseFloat((data as { lost: number }).lost.toFixed(1))
+        : null;
+      const valueText = lost ? (language === 'fr' ? `${lost} points` : `${lost} points`) : language === 'fr' ? 'du matériel' : 'material';
+      return language === 'fr'
+        ? `Ce coup perd ${valueText}. Cherche une défense plus solide.`
+        : `This move drops ${valueText}. Find a safer defence next time.`;
+    }
+    case 'fork-threat': {
+      const attacker = typeof (data as { attacker?: unknown }).attacker === 'string'
+        ? (data as { attacker: string }).attacker
+        : null;
+      const targets = listTargets((data as { targets?: unknown }).targets, language);
+      return language === 'fr'
+        ? `Un cavalier adverse depuis ${attacker ?? 'une case'} attaque ${targets}.` 
+          + ' Parer la fourchette en un coup.'
+        : `An opponent knight from ${attacker ?? 'a square'} is forking ${targets}. Block or move away now.`;
+    }
+    case 'pin': {
+      const square = describeSquare((data as { square?: unknown }).square, language);
+      const attacker = typeof (data as { attacker?: unknown }).attacker === 'string'
+        ? (data as { attacker: string }).attacker
+        : null;
+      return language === 'fr'
+        ? `Ta pièce sur ${square} est clouée par ${attacker ?? "la pièce adverse"}. Bouge une autre pièce pour la libérer.`
+        : `Your piece on ${square} is pinned by ${attacker ?? 'the opposing piece'}. Free it with support.`;
+    }
+    case 'missed-mate': {
+      const mateIn = typeof (data as { mateIn?: unknown }).mateIn === 'number'
+        ? (data as { mateIn: number }).mateIn
+        : null;
+      return language === 'fr'
+        ? `Il y avait un mat forcé en ${mateIn ?? '?'} coups. Cherche le schéma gagnant.`
+        : `There was a forced mate in ${mateIn ?? '?'} moves. Try to spot that winning pattern.`;
+    }
+    case 'mate-threat': {
+      const mateIn = typeof (data as { mateIn?: unknown }).mateIn === 'number'
+        ? (data as { mateIn: number }).mateIn
+        : null;
+      return language === 'fr'
+        ? `Après ce coup, l'adversaire peut mater en ${mateIn ?? '?'} coups. Crée une défense immédiate.`
+        : `After this move the opponent can mate in ${mateIn ?? '?'} moves. Find an urgent defence.`;
+    }
+    default:
+      return language === 'fr'
+        ? "Ce coup laisse un motif tactique dangereux."
+        : 'This move allows a tactical threat.';
+  }
+}
+
+function pickPrimaryPattern(patterns: DetectedPattern[]): DetectedPattern | null {
+  if (patterns.length === 0) return null;
+  return patterns.reduce((best, current) => {
+    const order = { critical: 3, warning: 2, info: 1 } as const;
+    return order[current.severity] > order[best.severity] ? current : best;
+  });
+}
+
+const FALLBACK_MESSAGES: Record<AnalysisTag, { fr: string; en: string; tone: CoachTone }> = {
+  ok: {
+    fr: 'Coup solide : tu restes dans le plan.',
+    en: 'Solid move—keep following the plan.',
+    tone: 'positive',
+  },
+  inaccuracy: {
+    fr: 'Ce coup est jouable mais laisse mieux ailleurs.',
+    en: 'Playable move, but there was a cleaner option.',
+    tone: 'info',
+  },
+  mistake: {
+    fr: "Imprécision : revois la menace adverse et cherche mieux.",
+    en: 'Inaccuracy—recheck the opponent threat and aim for better.',
+    tone: 'warning',
+  },
+  blunder: {
+    fr: 'Gaffe importante : la position se dégrade fortement.',
+    en: 'Big blunder—the position worsens a lot.',
+    tone: 'critical',
+  },
+  brilliant: {
+    fr: 'Excellent coup ! Tes pièces travaillent ensemble.',
+    en: 'Brilliant move! Your pieces work perfectly together.',
+    tone: 'positive',
+  },
+  great: {
+    fr: 'Très bon coup trouvé : tu tiens la position.',
+    en: 'Great move: you held the position together.',
+    tone: 'positive',
+  },
+};
+
+function enrichWithBestMove(text: string, language: CoachLanguage, bestMove: string): string {
+  if (!bestMove) return text;
+  const addition = language === 'fr'
+    ? ` Idée suggérée par le moteur : ${bestMove}.`
+    : ` Engine suggestion: ${bestMove}.`;
+  return `${text}${addition}`;
+}
+
+export function buildCoachMessage(context: CoachMessageContext): CoachMessage {
+  const primary = pickPrimaryPattern(context.patterns);
+  if (primary) {
+    const tone = severityToTone(primary.severity);
+    const fr = describePattern(primary, 'fr');
+    const en = describePattern(primary, 'en');
+    return { fr, en, tone, patterns: context.patterns };
+  }
+
+  const fallback = FALLBACK_MESSAGES[context.tag];
+  const frBase = fallback.fr;
+  const enBase = fallback.en;
+  const fr = context.tag === 'mistake' || context.tag === 'blunder' || context.tag === 'inaccuracy'
+    ? enrichWithBestMove(frBase, 'fr', context.bestMove)
+    : frBase;
+  const en = context.tag === 'mistake' || context.tag === 'blunder' || context.tag === 'inaccuracy'
+    ? enrichWithBestMove(enBase, 'en', context.bestMove)
+    : enBase;
+  return { fr, en, tone: fallback.tone, patterns: context.patterns };
+}

--- a/src/lib/analysis/patterns.ts
+++ b/src/lib/analysis/patterns.ts
@@ -1,0 +1,340 @@
+import { Chess, type PieceSymbol } from 'chess.js';
+
+export type PatternId =
+  | 'hanging-piece'
+  | 'material-drop'
+  | 'fork-threat'
+  | 'pin'
+  | 'missed-mate'
+  | 'mate-threat';
+
+export type PatternSeverity = 'info' | 'warning' | 'critical';
+
+export interface DetectedPattern {
+  id: PatternId;
+  severity: PatternSeverity;
+  data?: Record<string, unknown>;
+}
+
+export interface PatternDetectionContext {
+  color: 'w' | 'b';
+  fenBefore: string;
+  fenAfter: string;
+  evaluationBefore: number;
+  evaluationAfter: number;
+  delta: number;
+  mateInBefore?: number | null;
+  mateInAgainst?: number | null;
+}
+
+interface VerboseMove {
+  color: 'w' | 'b';
+  from: string;
+  to: string;
+  san: string;
+  flags: string;
+  piece: PieceSymbol;
+  captured?: PieceSymbol;
+  promotion?: PieceSymbol;
+}
+
+const PIECE_VALUES: Record<PieceSymbol, number> = {
+  p: 1,
+  n: 3,
+  b: 3,
+  r: 5,
+  q: 9,
+  k: 0,
+};
+
+const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
+
+const KNIGHT_OFFSETS: Array<[number, number]> = [
+  [1, 2],
+  [2, 1],
+  [2, -1],
+  [1, -2],
+  [-1, -2],
+  [-2, -1],
+  [-2, 1],
+  [-1, 2],
+];
+
+const ROOK_DIRECTIONS: Array<[number, number]> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const BISHOP_DIRECTIONS: Array<[number, number]> = [
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
+
+function coordsToSquare(file: number, rank: number): string | null {
+  if (file < 0 || file > 7 || rank < 0 || rank > 7) {
+    return null;
+  }
+  return `${FILES[file]}${rank + 1}`;
+}
+
+function squareToCoords(square: string): { file: number; rank: number } {
+  const file = FILES.indexOf(square[0] as typeof FILES[number]);
+  const rank = Number.parseInt(square[1] ?? '1', 10) - 1;
+  return { file, rank };
+}
+
+function evaluateMaterial(fen: string, color: 'w' | 'b'): number {
+  const board = new Chess(fen);
+  let total = 0;
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (piece && piece.color === color) {
+        total += PIECE_VALUES[piece.type];
+      }
+    }
+  }
+  return total;
+}
+
+function changeTurn(fen: string, color: 'w' | 'b'): string {
+  const parts = fen.split(' ');
+  if (parts.length >= 2) {
+    parts[1] = color;
+  }
+  return parts.join(' ');
+}
+
+function detectMaterialDrop(context: PatternDetectionContext): DetectedPattern | null {
+  const before = evaluateMaterial(context.fenBefore, context.color);
+  const after = evaluateMaterial(context.fenAfter, context.color);
+  const loss = before - after;
+  if (loss >= 3) {
+    return {
+      id: 'material-drop',
+      severity: 'critical',
+      data: { lost: loss },
+    };
+  }
+  if (loss >= 1.5 && context.delta < -100) {
+    return {
+      id: 'material-drop',
+      severity: 'warning',
+      data: { lost: loss },
+    };
+  }
+  return null;
+}
+
+function detectHangingPiece(context: PatternDetectionContext): DetectedPattern | null {
+  const opponentBoard = new Chess(context.fenAfter);
+  const opponentMoves = opponentBoard.moves({ verbose: true }) as VerboseMove[];
+  const captureTargets = new Map<string, VerboseMove[]>();
+
+  for (const move of opponentMoves) {
+    if (move.flags.includes('c') || move.flags.includes('e')) {
+      const existing = captureTargets.get(move.to) ?? [];
+      existing.push(move);
+      captureTargets.set(move.to, existing);
+    }
+  }
+
+  if (captureTargets.size === 0) return null;
+
+  const defendersBoard = new Chess(changeTurn(context.fenAfter, context.color));
+  const defenderMoves = defendersBoard.moves({ verbose: true }) as VerboseMove[];
+
+  let candidate: {
+    square: string;
+    move: VerboseMove;
+    piece: PieceSymbol;
+    value: number;
+  } | null = null;
+
+  for (const [square, moves] of captureTargets.entries()) {
+    const piece = opponentBoard.get(square as const);
+    if (!piece || piece.color !== context.color) continue;
+    const defenders = defenderMoves.filter((move) => move.to === square);
+    if (defenders.length > 0) continue;
+    const value = PIECE_VALUES[piece.type];
+    if (value === 0) continue;
+    if (!candidate || value > candidate.value) {
+      candidate = { square, move: moves[0], piece: piece.type, value };
+    }
+  }
+
+  if (!candidate) return null;
+
+  return {
+    id: 'hanging-piece',
+    severity: candidate.value >= 3 ? 'critical' : 'warning',
+    data: {
+      square: candidate.square,
+      piece: candidate.piece,
+      attackerFrom: candidate.move.from,
+    },
+  };
+}
+
+function detectForkThreat(context: PatternDetectionContext): DetectedPattern | null {
+  const board = new Chess(context.fenAfter);
+  const opponent = context.color === 'w' ? 'b' : 'w';
+  const threats: Array<{ attacker: string; targets: Array<{ square: string; piece: PieceSymbol; value: number }> }> = [];
+
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (!piece || piece.color !== opponent || piece.type !== 'n') continue;
+      const { file: knightFile, rank: knightRank } = squareToCoords(square);
+      const targets: Array<{ square: string; piece: PieceSymbol; value: number }> = [];
+      for (const [df, dr] of KNIGHT_OFFSETS) {
+        const targetSquare = coordsToSquare(knightFile + df, knightRank + dr);
+        if (!targetSquare) continue;
+        const targetPiece = board.get(targetSquare as const);
+        if (!targetPiece || targetPiece.color !== context.color) continue;
+        const value = PIECE_VALUES[targetPiece.type];
+        if (value < 3 && targetPiece.type !== 'k') continue;
+        targets.push({ square: targetSquare, piece: targetPiece.type, value });
+      }
+      if (targets.length >= 2) {
+        threats.push({ attacker: square, targets });
+      }
+    }
+  }
+
+  if (threats.length === 0) return null;
+
+  const mostSevere = threats.reduce((best, current) => {
+    const bestValue = best.targets.reduce((sum, target) => sum + target.value, 0);
+    const currentValue = current.targets.reduce((sum, target) => sum + target.value, 0);
+    return currentValue > bestValue ? current : best;
+  });
+
+  const severity = mostSevere.targets.some((target) => target.piece === 'q' || target.piece === 'k' || target.value >= 5)
+    ? 'critical'
+    : 'warning';
+
+  return {
+    id: 'fork-threat',
+    severity,
+    data: {
+      attacker: mostSevere.attacker,
+      targets: mostSevere.targets.map((target) => ({ square: target.square, piece: target.piece })),
+    },
+  };
+}
+
+function detectPinnedPieces(context: PatternDetectionContext): DetectedPattern | null {
+  const board = new Chess(context.fenAfter);
+  let kingSquare: string | null = null;
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (piece && piece.color === context.color && piece.type === 'k') {
+        kingSquare = square;
+      }
+    }
+  }
+  if (!kingSquare) return null;
+
+  const pinned: Array<{ square: string; piece: PieceSymbol; attacker: string }> = [];
+  const { file: kingFile, rank: kingRank } = squareToCoords(kingSquare);
+
+  const scanDirections = (
+    directions: Array<[number, number]>,
+    attackerTypes: PieceSymbol[],
+  ) => {
+    for (const [df, dr] of directions) {
+      let step = 1;
+      let candidate: { square: string; piece: PieceSymbol } | null = null;
+      while (true) {
+        const target = coordsToSquare(kingFile + df * step, kingRank + dr * step);
+        if (!target) break;
+        const occupant = board.get(target as const);
+        if (!occupant) {
+          step += 1;
+          continue;
+        }
+        if (occupant.color === context.color) {
+          if (candidate) break;
+          if (occupant.type === 'k') break;
+          candidate = { square: target, piece: occupant.type };
+          step += 1;
+          continue;
+        }
+        if (candidate && attackerTypes.includes(occupant.type)) {
+          pinned.push({ square: candidate.square, piece: candidate.piece, attacker: target });
+        }
+        break;
+      }
+    }
+  };
+
+  scanDirections(ROOK_DIRECTIONS, ['r', 'q']);
+  scanDirections(BISHOP_DIRECTIONS, ['b', 'q']);
+
+  if (pinned.length === 0) return null;
+
+  const mostValuable = pinned.reduce((best, current) =>
+    PIECE_VALUES[current.piece] > PIECE_VALUES[best.piece] ? current : best,
+  pinned[0]);
+
+  return {
+    id: 'pin',
+    severity: PIECE_VALUES[mostValuable.piece] >= 5 ? 'critical' : 'warning',
+    data: {
+      square: mostValuable.square,
+      piece: mostValuable.piece,
+      attacker: mostValuable.attacker,
+    },
+  };
+}
+
+function detectMissedMate(context: PatternDetectionContext): DetectedPattern | null {
+  if (!context.mateInBefore || context.mateInBefore <= 0) {
+    return null;
+  }
+  if (Math.abs(context.evaluationAfter) >= 90000) {
+    return null;
+  }
+  return {
+    id: 'missed-mate',
+    severity: context.mateInBefore <= 2 ? 'critical' : 'warning',
+    data: { mateIn: context.mateInBefore },
+  };
+}
+
+function detectMateThreat(context: PatternDetectionContext): DetectedPattern | null {
+  if (!context.mateInAgainst || context.mateInAgainst <= 0) {
+    return null;
+  }
+  return {
+    id: 'mate-threat',
+    severity: context.mateInAgainst <= 3 ? 'critical' : 'warning',
+    data: { mateIn: context.mateInAgainst },
+  };
+}
+
+export function detectPatterns(context: PatternDetectionContext): DetectedPattern[] {
+  const patterns: DetectedPattern[] = [];
+  const material = detectMaterialDrop(context);
+  if (material) patterns.push(material);
+  const hanging = detectHangingPiece(context);
+  if (hanging) patterns.push(hanging);
+  const fork = detectForkThreat(context);
+  if (fork) patterns.push(fork);
+  const pin = detectPinnedPieces(context);
+  if (pin) patterns.push(pin);
+  const missedMate = detectMissedMate(context);
+  if (missedMate) patterns.push(missedMate);
+  const mateThreat = detectMateThreat(context);
+  if (mateThreat) patterns.push(mateThreat);
+  return patterns;
+}

--- a/supabase/functions/analysis/patterns.ts
+++ b/supabase/functions/analysis/patterns.ts
@@ -1,0 +1,340 @@
+import { Chess, type PieceSymbol } from 'npm:chess.js';
+
+export type PatternId =
+  | 'hanging-piece'
+  | 'material-drop'
+  | 'fork-threat'
+  | 'pin'
+  | 'missed-mate'
+  | 'mate-threat';
+
+export type PatternSeverity = 'info' | 'warning' | 'critical';
+
+export interface DetectedPattern {
+  id: PatternId;
+  severity: PatternSeverity;
+  data?: Record<string, unknown>;
+}
+
+export interface PatternDetectionContext {
+  color: 'w' | 'b';
+  fenBefore: string;
+  fenAfter: string;
+  evaluationBefore: number;
+  evaluationAfter: number;
+  delta: number;
+  mateInBefore?: number | null;
+  mateInAgainst?: number | null;
+}
+
+interface VerboseMove {
+  color: 'w' | 'b';
+  from: string;
+  to: string;
+  san: string;
+  flags: string;
+  piece: PieceSymbol;
+  captured?: PieceSymbol;
+  promotion?: PieceSymbol;
+}
+
+const PIECE_VALUES: Record<PieceSymbol, number> = {
+  p: 1,
+  n: 3,
+  b: 3,
+  r: 5,
+  q: 9,
+  k: 0,
+};
+
+const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
+
+const KNIGHT_OFFSETS: Array<[number, number]> = [
+  [1, 2],
+  [2, 1],
+  [2, -1],
+  [1, -2],
+  [-1, -2],
+  [-2, -1],
+  [-2, 1],
+  [-1, 2],
+];
+
+const ROOK_DIRECTIONS: Array<[number, number]> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const BISHOP_DIRECTIONS: Array<[number, number]> = [
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+];
+
+function coordsToSquare(file: number, rank: number): string | null {
+  if (file < 0 || file > 7 || rank < 0 || rank > 7) {
+    return null;
+  }
+  return `${FILES[file]}${rank + 1}`;
+}
+
+function squareToCoords(square: string): { file: number; rank: number } {
+  const file = FILES.indexOf(square[0] as typeof FILES[number]);
+  const rank = Number.parseInt(square[1] ?? '1', 10) - 1;
+  return { file, rank };
+}
+
+function evaluateMaterial(fen: string, color: 'w' | 'b'): number {
+  const board = new Chess(fen);
+  let total = 0;
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (piece && piece.color === color) {
+        total += PIECE_VALUES[piece.type];
+      }
+    }
+  }
+  return total;
+}
+
+function changeTurn(fen: string, color: 'w' | 'b'): string {
+  const parts = fen.split(' ');
+  if (parts.length >= 2) {
+    parts[1] = color;
+  }
+  return parts.join(' ');
+}
+
+function detectMaterialDrop(context: PatternDetectionContext): DetectedPattern | null {
+  const before = evaluateMaterial(context.fenBefore, context.color);
+  const after = evaluateMaterial(context.fenAfter, context.color);
+  const loss = before - after;
+  if (loss >= 3) {
+    return {
+      id: 'material-drop',
+      severity: 'critical',
+      data: { lost: loss },
+    };
+  }
+  if (loss >= 1.5 && context.delta < -100) {
+    return {
+      id: 'material-drop',
+      severity: 'warning',
+      data: { lost: loss },
+    };
+  }
+  return null;
+}
+
+function detectHangingPiece(context: PatternDetectionContext): DetectedPattern | null {
+  const opponentBoard = new Chess(context.fenAfter);
+  const opponentMoves = opponentBoard.moves({ verbose: true }) as VerboseMove[];
+  const captureTargets = new Map<string, VerboseMove[]>();
+
+  for (const move of opponentMoves) {
+    if (move.flags.includes('c') || move.flags.includes('e')) {
+      const existing = captureTargets.get(move.to) ?? [];
+      existing.push(move);
+      captureTargets.set(move.to, existing);
+    }
+  }
+
+  if (captureTargets.size === 0) return null;
+
+  const defendersBoard = new Chess(changeTurn(context.fenAfter, context.color));
+  const defenderMoves = defendersBoard.moves({ verbose: true }) as VerboseMove[];
+
+  let candidate: {
+    square: string;
+    move: VerboseMove;
+    piece: PieceSymbol;
+    value: number;
+  } | null = null;
+
+  for (const [square, moves] of captureTargets.entries()) {
+    const piece = opponentBoard.get(square as const);
+    if (!piece || piece.color !== context.color) continue;
+    const defenders = defenderMoves.filter((move) => move.to === square);
+    if (defenders.length > 0) continue;
+    const value = PIECE_VALUES[piece.type];
+    if (value === 0) continue;
+    if (!candidate || value > candidate.value) {
+      candidate = { square, move: moves[0], piece: piece.type, value };
+    }
+  }
+
+  if (!candidate) return null;
+
+  return {
+    id: 'hanging-piece',
+    severity: candidate.value >= 3 ? 'critical' : 'warning',
+    data: {
+      square: candidate.square,
+      piece: candidate.piece,
+      attackerFrom: candidate.move.from,
+    },
+  };
+}
+
+function detectForkThreat(context: PatternDetectionContext): DetectedPattern | null {
+  const board = new Chess(context.fenAfter);
+  const opponent = context.color === 'w' ? 'b' : 'w';
+  const threats: Array<{ attacker: string; targets: Array<{ square: string; piece: PieceSymbol; value: number }> }> = [];
+
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (!piece || piece.color !== opponent || piece.type !== 'n') continue;
+      const { file: knightFile, rank: knightRank } = squareToCoords(square);
+      const targets: Array<{ square: string; piece: PieceSymbol; value: number }> = [];
+      for (const [df, dr] of KNIGHT_OFFSETS) {
+        const targetSquare = coordsToSquare(knightFile + df, knightRank + dr);
+        if (!targetSquare) continue;
+        const targetPiece = board.get(targetSquare as const);
+        if (!targetPiece || targetPiece.color !== context.color) continue;
+        const value = PIECE_VALUES[targetPiece.type];
+        if (value < 3 && targetPiece.type !== 'k') continue;
+        targets.push({ square: targetSquare, piece: targetPiece.type, value });
+      }
+      if (targets.length >= 2) {
+        threats.push({ attacker: square, targets });
+      }
+    }
+  }
+
+  if (threats.length === 0) return null;
+
+  const mostSevere = threats.reduce((best, current) => {
+    const bestValue = best.targets.reduce((sum, target) => sum + target.value, 0);
+    const currentValue = current.targets.reduce((sum, target) => sum + target.value, 0);
+    return currentValue > bestValue ? current : best;
+  });
+
+  const severity = mostSevere.targets.some((target) => target.piece === 'q' || target.piece === 'k' || target.value >= 5)
+    ? 'critical'
+    : 'warning';
+
+  return {
+    id: 'fork-threat',
+    severity,
+    data: {
+      attacker: mostSevere.attacker,
+      targets: mostSevere.targets.map((target) => ({ square: target.square, piece: target.piece })),
+    },
+  };
+}
+
+function detectPinnedPieces(context: PatternDetectionContext): DetectedPattern | null {
+  const board = new Chess(context.fenAfter);
+  let kingSquare: string | null = null;
+  for (const file of FILES) {
+    for (let rank = 1; rank <= 8; rank += 1) {
+      const square = `${file}${rank}`;
+      const piece = board.get(square as const);
+      if (piece && piece.color === context.color && piece.type === 'k') {
+        kingSquare = square;
+      }
+    }
+  }
+  if (!kingSquare) return null;
+
+  const pinned: Array<{ square: string; piece: PieceSymbol; attacker: string }> = [];
+  const { file: kingFile, rank: kingRank } = squareToCoords(kingSquare);
+
+  const scanDirections = (
+    directions: Array<[number, number]>,
+    attackerTypes: PieceSymbol[],
+  ) => {
+    for (const [df, dr] of directions) {
+      let step = 1;
+      let candidate: { square: string; piece: PieceSymbol } | null = null;
+      while (true) {
+        const target = coordsToSquare(kingFile + df * step, kingRank + dr * step);
+        if (!target) break;
+        const occupant = board.get(target as const);
+        if (!occupant) {
+          step += 1;
+          continue;
+        }
+        if (occupant.color === context.color) {
+          if (candidate) break;
+          if (occupant.type === 'k') break;
+          candidate = { square: target, piece: occupant.type };
+          step += 1;
+          continue;
+        }
+        if (candidate && attackerTypes.includes(occupant.type)) {
+          pinned.push({ square: candidate.square, piece: candidate.piece, attacker: target });
+        }
+        break;
+      }
+    }
+  };
+
+  scanDirections(ROOK_DIRECTIONS, ['r', 'q']);
+  scanDirections(BISHOP_DIRECTIONS, ['b', 'q']);
+
+  if (pinned.length === 0) return null;
+
+  const mostValuable = pinned.reduce((best, current) =>
+    PIECE_VALUES[current.piece] > PIECE_VALUES[best.piece] ? current : best,
+  pinned[0]);
+
+  return {
+    id: 'pin',
+    severity: PIECE_VALUES[mostValuable.piece] >= 5 ? 'critical' : 'warning',
+    data: {
+      square: mostValuable.square,
+      piece: mostValuable.piece,
+      attacker: mostValuable.attacker,
+    },
+  };
+}
+
+function detectMissedMate(context: PatternDetectionContext): DetectedPattern | null {
+  if (!context.mateInBefore || context.mateInBefore <= 0) {
+    return null;
+  }
+  if (Math.abs(context.evaluationAfter) >= 90000) {
+    return null;
+  }
+  return {
+    id: 'missed-mate',
+    severity: context.mateInBefore <= 2 ? 'critical' : 'warning',
+    data: { mateIn: context.mateInBefore },
+  };
+}
+
+function detectMateThreat(context: PatternDetectionContext): DetectedPattern | null {
+  if (!context.mateInAgainst || context.mateInAgainst <= 0) {
+    return null;
+  }
+  return {
+    id: 'mate-threat',
+    severity: context.mateInAgainst <= 3 ? 'critical' : 'warning',
+    data: { mateIn: context.mateInAgainst },
+  };
+}
+
+export function detectPatterns(context: PatternDetectionContext): DetectedPattern[] {
+  const patterns: DetectedPattern[] = [];
+  const material = detectMaterialDrop(context);
+  if (material) patterns.push(material);
+  const hanging = detectHangingPiece(context);
+  if (hanging) patterns.push(hanging);
+  const fork = detectForkThreat(context);
+  if (fork) patterns.push(fork);
+  const pin = detectPinnedPieces(context);
+  if (pin) patterns.push(pin);
+  const missedMate = detectMissedMate(context);
+  if (missedMate) patterns.push(missedMate);
+  const mateThreat = detectMateThreat(context);
+  if (mateThreat) patterns.push(mateThreat);
+  return patterns;
+}


### PR DESCRIPTION
## Summary
- implement reusable pattern detectors on the Supabase analysis edge function and expose motif data with each move
- mirror the detection logic on the client, generate bilingual rule-based coach messages, and attach them to move analyses
- refresh the GameReviewPanel to surface "Pourquoi ?" explanations with motif badges and a "Voir la ligne" action

## Testing
- npm run lint *(warnings about fast refresh re-exports persist)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb2e3c9f08323878c7b9facf53be1