### PR TITLE
Fix Supabase custom rules function model configuration

### DIFF
--- a/supabase/functions/generate-custom-rules/index.ts
+++ b/supabase/functions/generate-custom-rules/index.ts
@@ -45,18 +45,18 @@ INSTRUCTIONS:
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini-2025-08-07',
+        model: 'gpt-4o-mini',
         messages: [
-          { 
-            role: 'system', 
+          {
+            role: 'system',
             content: systemPrompt
           },
-          { 
-            role: 'user', 
+          {
+            role: 'user',
             content: `Crée des règles d'échecs personnalisées basées sur cette description: ${description}`
           }
         ],
-        max_completion_tokens: 800,
+        max_tokens: 800,
       }),
     });
 


### PR DESCRIPTION
## Summary
- update the generate-custom-rules Supabase function to use a supported OpenAI chat model
- switch to the correct max_tokens parameter to avoid API validation errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcb7ae0a60832380acee2db8bd726d