### PR TITLE
Add multi-style chess bot service and UI components

### DIFF
--- a/src/features/bots/BotPicker.tsx
+++ b/src/features/bots/BotPicker.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { supabase } from "@/services/supabase/client";
+import type { Tables } from "@/services/supabase/types";
+import { cn } from "@/lib/utils";
+
+interface ParsedBotStyle {
+  label: string;
+  personality: string;
+  description: string;
+  traits: string[];
+}
+
+interface ParsedBotProfile {
+  row: Tables<"bot_profiles">;
+  style: ParsedBotStyle;
+}
+
+interface BotPickerProps {
+  onSelect?: (bot: Tables<"bot_profiles">) => void;
+  selectedBotId?: string;
+  className?: string;
+  autoSelectFirst?: boolean;
+}
+
+function toArrayOfStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function parseStyle(style: unknown): ParsedBotStyle {
+  if (!style || typeof style !== "object" || Array.isArray(style)) {
+    return {
+      label: "Inconnu",
+      personality: "Style non spécifié",
+      description: "Aucune description disponible.",
+      traits: [],
+    };
+  }
+
+  const data = style as Record<string, unknown>;
+  return {
+    label: typeof data.label === "string" ? data.label : "Inconnu",
+    personality: typeof data.personality === "string" ? data.personality : "Style non spécifié",
+    description: typeof data.description === "string" ? data.description : "Aucune description disponible.",
+    traits: toArrayOfStrings(data.traits),
+  };
+}
+
+export function BotPicker({
+  onSelect,
+  selectedBotId,
+  className,
+  autoSelectFirst = false,
+}: BotPickerProps) {
+  const [bots, setBots] = useState<ParsedBotProfile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoading(true);
+    void supabase
+      .from("bot_profiles")
+      .select("*")
+      .order("elo_target", { ascending: true })
+      .then((response) => {
+        if (!isMounted) return;
+        if (response.error) {
+          console.error("Failed to load bot profiles", response.error);
+          setError("Impossible de charger les profils de bots.");
+          setBots([]);
+          return;
+        }
+        const parsed = (response.data ?? []).map((row) => ({
+          row,
+          style: parseStyle(row.style),
+        }));
+        setBots(parsed);
+        setError(null);
+        if (autoSelectFirst && !selectedBotId && parsed.length > 0 && onSelect) {
+          onSelect(parsed[0].row);
+        }
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [autoSelectFirst, onSelect, selectedBotId]);
+
+  const selected = useMemo(
+    () => bots.find((bot) => bot.row.id === selectedBotId)?.row ?? null,
+    [bots, selectedBotId],
+  );
+
+  const handleSelect = (bot: Tables<"bot_profiles">) => {
+    if (onSelect) {
+      onSelect(bot);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className={cn("grid gap-4 md:grid-cols-2 xl:grid-cols-3", className)}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Card key={index} className="p-6">
+            <div className="flex flex-col gap-4">
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <div className="flex gap-2">
+                <Skeleton className="h-6 w-16" />
+                <Skeleton className="h-6 w-20" />
+              </div>
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={cn("rounded-md border border-destructive/40 bg-destructive/10 p-4 text-destructive", className)}>
+        {error}
+      </div>
+    );
+  }
+
+  if (bots.length === 0) {
+    return (
+      <div className={cn("rounded-md border border-dashed p-6 text-center text-muted-foreground", className)}>
+        Aucun profil de bot n'est disponible pour le moment.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("grid gap-4 md:grid-cols-2 xl:grid-cols-3", className)}>
+      {bots.map(({ row, style }) => {
+        const isSelected = selected?.id === row.id;
+        return (
+          <Card
+            key={row.id}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleSelect(row)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleSelect(row);
+              }
+            }}
+            className={cn(
+              "relative flex h-full flex-col border transition-all",
+              "hover:border-primary/40 hover:shadow-lg",
+              isSelected && "border-primary shadow-lg",
+            )}
+          >
+            <CardHeader className="space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <CardTitle className="text-xl font-semibold">{row.name}</CardTitle>
+                <Badge variant={isSelected ? "default" : "secondary"}>{style.label}</Badge>
+              </div>
+              <CardDescription className="text-muted-foreground">
+                {style.personality}
+              </CardDescription>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Badge variant="outline" className="font-mono text-xs uppercase">
+                  Elo ~ {row.elo_target}
+                </Badge>
+                <span>•</span>
+                <span>{style.description}</span>
+              </div>
+            </CardHeader>
+            <CardContent className="flex-1 space-y-4">
+              {style.traits.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {style.traits.map((trait) => (
+                    <Badge key={trait} variant="outline" className="rounded-full border-primary/20 bg-primary/5 text-xs">
+                      {trait}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+            <CardFooter>
+              <Button
+                type="button"
+                variant={isSelected ? "default" : "outline"}
+                className="w-full"
+                onClick={() => handleSelect(row)}
+              >
+                {isSelected ? "Sélectionné" : "Choisir ce bot"}
+              </Button>
+            </CardFooter>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+export default BotPicker;

--- a/src/features/bots/index.ts
+++ b/src/features/bots/index.ts
@@ -1,0 +1,2 @@
+export { BotPicker } from "./BotPicker";
+export type { BotProfileRow } from "@/services/botsClient";

--- a/src/features/play/BoardWithBot.tsx
+++ b/src/features/play/BoardWithBot.tsx
@@ -1,0 +1,375 @@
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Canvas } from "@react-three/fiber";
+import { Environment, OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import type { Group } from "three";
+import { Chess } from "chess.js";
+import type { Move as ChessJsMove } from "chess.js";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, RefreshCw, ShieldQuestion } from "lucide-react";
+import { ChessBoard3D } from "@/components/ChessBoard3D";
+import { MoveHistory } from "@/components/MoveHistory";
+import { toast } from "sonner";
+import type { Tables } from "@/services/supabase/types";
+import {
+  createBotSession,
+  requestBotMove,
+  type BotMoveAnalysis,
+  type BotMoveGameOver,
+  type BotMoveSuccess,
+} from "@/services/botsClient";
+import { cn } from "@/lib/utils";
+
+interface BoardWithBotProps {
+  bot: Tables<"bot_profiles"> | null;
+  orientation?: "white" | "black";
+  className?: string;
+}
+
+type SelectionState = {
+  square: string;
+  moves: ChessJsMove[];
+} | null;
+
+function getPlayerTurn(orientation: "white" | "black") {
+  return orientation === "white" ? "w" : "b";
+}
+
+function isGameOverResponse(response: BotMoveSuccess | BotMoveGameOver): response is BotMoveGameOver {
+  return "status" in response && response.status === "game_over";
+}
+
+export function BoardWithBot({ bot, orientation = "white", className }: BoardWithBotProps) {
+  const chessRef = useRef(new Chess());
+  const boardRef = useRef<Group>(null);
+  const sanHistoryRef = useRef<string[]>([]);
+  const moveHistoryRef = useRef<ChessJsMove[]>([]);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [fen, setFen] = useState(chessRef.current.fen());
+  const [moveHistory, setMoveHistory] = useState<ChessJsMove[]>([]);
+  const [analysis, setAnalysis] = useState<BotMoveAnalysis | null>(null);
+  const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
+  const [selection, setSelection] = useState<SelectionState>(null);
+  const [possibleMoves, setPossibleMoves] = useState<string[]>([]);
+  const [isThinking, setIsThinking] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
+  const [status, setStatus] = useState<"idle" | "ready" | "playing" | "game_over" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [sessionVersion, setSessionVersion] = useState(0);
+
+  const playerTurn = useMemo(() => getPlayerTurn(orientation), [orientation]);
+
+  const resetBoard = useCallback(() => {
+    chessRef.current = new Chess();
+    sanHistoryRef.current = [];
+    moveHistoryRef.current = [];
+    setFen(chessRef.current.fen());
+    setMoveHistory([]);
+    setAnalysis(null);
+    setLastMove(null);
+    setSelection(null);
+    setPossibleMoves([]);
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  const updateHistories = useCallback((move: ChessJsMove) => {
+    const updatedSan = [...sanHistoryRef.current, move.san];
+    const updatedVerbose = [...moveHistoryRef.current, move];
+    sanHistoryRef.current = updatedSan;
+    moveHistoryRef.current = updatedVerbose;
+    setMoveHistory(updatedVerbose);
+  }, []);
+
+  const applyBotMove = useCallback((response: BotMoveSuccess) => {
+    const chess = chessRef.current;
+    let move = chess.move({
+      from: response.move.from,
+      to: response.move.to,
+      promotion: response.move.promotion ?? undefined,
+    });
+    if (!move) {
+      move = chess.move(response.move.san, { sloppy: true });
+    }
+    if (!move) {
+      throw new Error("Le coup renvoyé par le bot est illégal dans cette position.");
+    }
+    return move;
+  }, []);
+
+  const performBotTurn = useCallback(
+    async (session: string | null = null, skipDelay = false) => {
+      if (!bot) return;
+      const activeSession = session ?? sessionId;
+      if (!activeSession) return;
+
+      if (!skipDelay) {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+      }
+
+      setIsThinking(true);
+      try {
+        const response = await requestBotMove({
+          botId: bot.id,
+          sessionId: activeSession,
+          moves: sanHistoryRef.current,
+        });
+
+        if (isGameOverResponse(response)) {
+          setStatus("game_over");
+          setAnalysis(null);
+          setError(null);
+          return;
+        }
+
+        const moveResult = applyBotMove(response);
+        updateHistories(moveResult);
+        setFen(chessRef.current.fen());
+        setLastMove({ from: moveResult.from, to: moveResult.to });
+        setAnalysis(response.analysis);
+        setStatus(chessRef.current.isGameOver() ? "game_over" : "playing");
+      } catch (err) {
+        console.error("Bot move error", err);
+        const message = err instanceof Error ? err.message : "Erreur inconnue";
+        setError(message);
+        setStatus("error");
+        toast.error("Le bot ne répond plus", { description: message });
+      } finally {
+        setIsThinking(false);
+      }
+    },
+    [applyBotMove, bot, sessionId, updateHistories],
+  );
+
+  const startSession = useCallback(async () => {
+    if (!bot) {
+      setSessionId(null);
+      return;
+    }
+    resetBoard();
+    setIsStarting(true);
+    setStatus("idle");
+    setSessionId(null);
+    try {
+      const session = await createBotSession(bot.id);
+      setSessionId(session.sessionId);
+      setStatus("ready");
+      if (orientation === "black") {
+        await performBotTurn(session.sessionId, true);
+      }
+    } catch (err) {
+      console.error("Failed to start bot session", err);
+      const message = err instanceof Error ? err.message : "Erreur inconnue";
+      setError(message);
+      setStatus("error");
+      toast.error("Impossible de créer la session bot", { description: message });
+    } finally {
+      setIsStarting(false);
+    }
+  }, [bot, orientation, performBotTurn, resetBoard]);
+
+  useEffect(() => {
+    void startSession();
+  }, [startSession, sessionVersion]);
+
+  useEffect(() => {
+    return () => {
+      chessRef.current = new Chess();
+      sanHistoryRef.current = [];
+      moveHistoryRef.current = [];
+    };
+  }, []);
+
+  const handlePlayerMove = useCallback(
+    async (candidate: ChessJsMove) => {
+      const chess = chessRef.current;
+      const executed = chess.move({
+        from: candidate.from,
+        to: candidate.to,
+        promotion: candidate.promotion ?? "q",
+      });
+      if (!executed) {
+        return;
+      }
+      updateHistories(executed);
+      setFen(chess.fen());
+      setLastMove({ from: executed.from, to: executed.to });
+      setAnalysis(null);
+      setSelection(null);
+      setPossibleMoves([]);
+      setStatus(chess.isGameOver() ? "game_over" : "playing");
+
+      if (chess.isGameOver()) {
+        return;
+      }
+
+      await performBotTurn();
+    },
+    [performBotTurn, updateHistories],
+  );
+
+  const handleSquareClick = useCallback(
+    (square: string) => {
+      if (!bot || isThinking || status === "game_over" || status === "error") {
+        return;
+      }
+      const chess = chessRef.current;
+      if (chess.turn() !== playerTurn) {
+        setSelection(null);
+        setPossibleMoves([]);
+        return;
+      }
+
+      if (selection && selection.square !== square) {
+        const move = selection.moves.find((candidate) => candidate.to === square);
+        if (move) {
+          void handlePlayerMove(move);
+          return;
+        }
+      }
+
+      const moves = (chess.moves({ square, verbose: true }) as ChessJsMove[]).filter(
+        (candidate) => candidate.color === playerTurn,
+      );
+
+      if (moves.length === 0) {
+        setSelection(null);
+        setPossibleMoves([]);
+        return;
+      }
+
+      setSelection({ square, moves });
+      setPossibleMoves(moves.map((move) => move.to));
+    },
+    [bot, handlePlayerMove, isThinking, playerTurn, selection, status],
+  );
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case "idle":
+        return "Sélectionnez un coup";
+      case "ready":
+        return orientation === "black" ? "Le bot commence la partie" : "À vous de jouer";
+      case "playing":
+        return isThinking ? "Le bot réfléchit..." : "Partie en cours";
+      case "game_over":
+        return chessRef.current.isCheckmate() ? "Échec et mat" : "Partie terminée";
+      case "error":
+        return "Erreur de session";
+      default:
+        return "";
+    }
+  }, [isThinking, orientation, status]);
+
+  const handleRestart = () => {
+    setSessionVersion((version) => version + 1);
+  };
+
+  return (
+    <div className={cn("grid gap-6 lg:grid-cols-[2fr,1fr]", className)}>
+      <Card className="overflow-hidden">
+        <CardHeader className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <CardTitle className="text-2xl font-semibold">
+              {bot ? bot.name : "Choisissez un bot"}
+            </CardTitle>
+            {bot && <Badge variant="outline">Elo cible ~ {bot.elo_target}</Badge>}
+            {bot && (
+              <Badge variant="secondary" className="capitalize">
+                {typeof bot.style === "object" && !Array.isArray(bot.style) && bot.style
+                  ? ((bot.style as Record<string, unknown>).label as string | undefined) ?? "Bot"
+                  : "Bot"}
+              </Badge>
+            )}
+          </div>
+          <CardDescription className="flex items-center gap-2 text-sm">
+            <span>{statusLabel}</span>
+            {(isStarting || (isThinking && !isStarting)) && (
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="relative aspect-square w-full">
+            <Canvas shadows>
+              <ambientLight intensity={0.6} />
+              <directionalLight position={[5, 10, 5]} intensity={0.9} castShadow />
+              <PerspectiveCamera makeDefault position={[8, 10, 8]} />
+              <OrbitControls enablePan={false} maxPolarAngle={Math.PI / 2.2} minPolarAngle={Math.PI / 6} />
+              <Environment preset="city" />
+              <ChessBoard3D
+                ref={boardRef}
+                position={fen}
+                onSquareClick={handleSquareClick}
+                selectedSquare={selection?.square ?? null}
+                possibleMoves={possibleMoves}
+                lastMove={lastMove}
+              />
+            </Canvas>
+            {isThinking && (
+              <div className="absolute inset-0 flex items-center justify-center bg-background/60 text-primary">
+                Le bot réfléchit...
+              </div>
+            )}
+          </div>
+          {analysis && (
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Badge variant={analysis.source === "book" ? "secondary" : "default"}>
+                  {analysis.source === "book" ? "Livre" : "Moteur"}
+                </Badge>
+                {analysis.evaluation && (
+                  <span>
+                    Évaluation: {analysis.evaluation.type === "cp"
+                      ? `${(analysis.evaluation.value / 100).toFixed(2)}`
+                      : `Mat en ${analysis.evaluation.value}`}
+                  </span>
+                )}
+              </div>
+              {analysis.principalVariationSan.length > 0 && (
+                <div className="flex flex-wrap gap-2 text-xs font-mono">
+                  {analysis.principalVariationSan.slice(0, 6).map((san, index) => (
+                    <span key={`${san}-${index}`} className="rounded bg-muted px-2 py-1">
+                      {san}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="flex items-center justify-between gap-3">
+          <Button type="button" variant="outline" onClick={handleRestart} disabled={isStarting}>
+            <RefreshCw className="mr-2 h-4 w-4" /> Nouvelle partie
+          </Button>
+          <Badge variant="outline" className="font-mono uppercase">
+            Vous jouez les {orientation === "white" ? "blancs" : "noirs"}
+          </Badge>
+        </CardFooter>
+      </Card>
+      <div className="flex flex-col gap-4">
+        {error && (
+          <Alert variant="destructive">
+            <ShieldQuestion className="h-4 w-4" />
+            <AlertTitle>Erreur</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <MoveHistory moves={moveHistory} />
+      </div>
+    </div>
+  );
+}
+
+export default BoardWithBot;

--- a/src/features/play/index.ts
+++ b/src/features/play/index.ts
@@ -1,3 +1,4 @@
 export { default as ChessHome } from "./routes/ChessHome";
 export { default as ChessGame } from "./routes/ChessGame";
 export { default as Lobby } from "./routes/Lobby";
+export { default as BoardWithBot } from "./BoardWithBot";

--- a/src/services/botsClient.ts
+++ b/src/services/botsClient.ts
@@ -1,0 +1,109 @@
+
+import type { Tables } from "@/services/supabase/types";
+
+const EDGE_BASE_URL = "/functions/v1/bots";
+
+export interface BotProfilePublic {
+  id: string;
+  name: string;
+  elo_target: number;
+  style: Record<string, unknown>;
+  book: Record<string, unknown>;
+}
+
+export interface BotSessionResponse {
+  sessionId: string;
+  bot: BotProfilePublic;
+}
+
+export type EvaluationType = "cp" | "mate";
+
+export interface EvaluationPayload {
+  type: EvaluationType;
+  value: number;
+}
+
+export interface BotMultipvLine {
+  multipv: number;
+  move: string;
+  pv: string[];
+  evaluation: EvaluationPayload;
+}
+
+export interface BotMoveAnalysis {
+  source: "book" | "engine";
+  evaluation: EvaluationPayload | null;
+  principalVariation: string[];
+  principalVariationSan: string[];
+  multipv?: BotMultipvLine[];
+  bookLine?: { name?: string; moves?: string[] };
+}
+
+export interface BotMoveSuccess {
+  sessionId: string | null;
+  botId: string;
+  fenBefore: string;
+  fenAfter: string;
+  move: {
+    from: string;
+    to: string;
+    san: string;
+    uci: string;
+    lan?: string;
+    promotion?: string | null;
+  };
+  analysis: BotMoveAnalysis;
+}
+
+export interface BotMoveGameOver {
+  status: "game_over";
+  reason: string;
+  fen: string;
+  sessionId?: string | null;
+  botId?: string;
+}
+
+export interface BotMoveRequest {
+  botId: string;
+  sessionId?: string | null;
+  moves?: string[];
+  initialFen?: string;
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const data = await response.json();
+      if (typeof data?.error === "string") {
+        message = data.error;
+      }
+    } catch (_) {
+      // ignore json parsing error
+    }
+    throw new Error(message);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function createBotSession(botId: string): Promise<BotSessionResponse> {
+  const response = await fetch(`${EDGE_BASE_URL}/new`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ botId }),
+  });
+  return handleResponse<BotSessionResponse>(response);
+}
+
+export async function requestBotMove(
+  request: BotMoveRequest,
+): Promise<BotMoveSuccess | BotMoveGameOver> {
+  const response = await fetch(`${EDGE_BASE_URL}/move`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  return handleResponse<BotMoveSuccess | BotMoveGameOver>(response);
+}
+
+export type BotProfileRow = Tables<"bot_profiles">;

--- a/src/services/supabase/types.ts
+++ b/src/services/supabase/types.ts
@@ -53,6 +53,33 @@ export type Database = {
         }
         Relationships: []
       }
+      bot_profiles: {
+        Row: {
+          book: Json
+          created_at: string
+          elo_target: number
+          id: string
+          name: string
+          style: Json
+        }
+        Insert: {
+          book: Json
+          created_at?: string
+          elo_target: number
+          id?: string
+          name: string
+          style: Json
+        }
+        Update: {
+          book?: Json
+          created_at?: string
+          elo_target?: number
+          id?: string
+          name?: string
+          style?: Json
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/functions/bots/index.ts
+++ b/supabase/functions/bots/index.ts
@@ -1,0 +1,209 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { Chess } from 'npm:chess.js';
+import type { Move as ChessJsMove } from 'npm:chess.js';
+import { BOT_PROFILES, getProfileById } from './profiles.ts';
+import {
+  analyseWithEngine,
+  applyUciMove,
+  pvToSanSequence,
+  selectBookMove,
+} from './play.ts';
+import type { BotProfileConfig, MultipvLine, SelectedBookMove } from './types.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+interface NewSessionRequest {
+  botId?: string;
+}
+
+interface BotMoveRequest {
+  botId?: string;
+  sessionId?: string;
+  moves?: string[];
+  initialFen?: string;
+}
+
+interface MovePayload {
+  from: string;
+  to: string;
+  san: string;
+  uci: string;
+  lan?: string;
+  promotion?: string | null;
+}
+
+interface MoveAnalysisPayload {
+  source: 'book' | 'engine';
+  evaluation: { type: 'cp' | 'mate'; value: number } | null;
+  principalVariation: string[];
+  principalVariationSan: string[];
+  multipv?: MultipvLine[];
+  bookLine?: { name?: string; moves?: string[] };
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function sanitizeProfile(profile: BotProfileConfig) {
+  const { style, book, ...rest } = profile;
+  const { engine, ...publicStyle } = style;
+  return { ...rest, style: publicStyle, book };
+}
+
+function buildMovePayload(move: ChessJsMove): MovePayload {
+  const uci = `${move.from}${move.to}${move.promotion ?? ''}`;
+  return {
+    from: move.from,
+    to: move.to,
+    san: move.san,
+    uci,
+    lan: move.lan,
+    promotion: move.promotion ?? null,
+  };
+}
+
+function validateHistory(moves: string[] = [], initialFen?: string) {
+  const board = new Chess();
+  if (initialFen) {
+    const ok = board.load(initialFen);
+    if (!ok) {
+      throw new Error('Invalid initial FEN provided');
+    }
+  }
+
+  for (const san of moves) {
+    const move = board.move(san, { sloppy: true });
+    if (!move) {
+      throw new Error(`Invalid SAN move in history: ${san}`);
+    }
+  }
+
+  return board;
+}
+
+function buildBookAnalysis(selected: SelectedBookMove | null): MoveAnalysisPayload {
+  return {
+    source: 'book',
+    evaluation: null,
+    principalVariation: [],
+    principalVariationSan: [],
+    bookLine: selected?.line ? { name: selected.line.name, moves: selected.line.moves } : undefined,
+  };
+}
+
+function buildEngineAnalysis(
+  fen: string,
+  chosen: MultipvLine,
+  lines: MultipvLine[],
+): MoveAnalysisPayload {
+  return {
+    source: 'engine',
+    evaluation: chosen.evaluation,
+    principalVariation: chosen.pv,
+    principalVariationSan: pvToSanSequence(fen, chosen.pv),
+    multipv: lines,
+  };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const { pathname } = new URL(req.url);
+
+  try {
+    if (req.method === 'GET' && pathname.endsWith('/profiles')) {
+      return jsonResponse(200, { bots: BOT_PROFILES.map(sanitizeProfile) });
+    }
+
+    if (req.method === 'POST' && pathname.endsWith('/new')) {
+      const payload: NewSessionRequest = await req.json().catch(() => ({}));
+      const botId = payload.botId ?? BOT_PROFILES[0]?.id;
+      if (!botId) {
+        return jsonResponse(400, { error: 'no_bot_available' });
+      }
+      const profile = getProfileById(botId);
+      if (!profile) {
+        return jsonResponse(404, { error: 'bot_not_found' });
+      }
+
+      return jsonResponse(200, {
+        sessionId: crypto.randomUUID(),
+        bot: sanitizeProfile(profile),
+      });
+    }
+
+    if (req.method === 'POST' && pathname.endsWith('/move')) {
+      const payload: BotMoveRequest = await req.json().catch(() => ({}));
+      if (!payload.botId) {
+        return jsonResponse(400, { error: 'missing_bot_id' });
+      }
+      const profile = getProfileById(payload.botId);
+      if (!profile) {
+        return jsonResponse(404, { error: 'bot_not_found' });
+      }
+
+      const history = Array.isArray(payload.moves)
+        ? payload.moves.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+      const board = validateHistory(history, payload.initialFen);
+      const fenBefore = board.fen();
+
+      if (board.isGameOver()) {
+        return jsonResponse(200, {
+          status: 'game_over',
+          reason: board.isCheckmate() ? 'checkmate' : board.isDraw() ? 'draw' : 'finished',
+          fen: fenBefore,
+        });
+      }
+
+      const bookMove = selectBookMove(profile.book, history);
+      if (bookMove) {
+        const bookBoard = new Chess();
+        bookBoard.load(fenBefore);
+        const move = bookBoard.move(bookMove.move, { sloppy: true });
+        if (!move) {
+          console.warn(`Book move ${bookMove.move} invalid for ${fenBefore}, fallback to engine.`);
+        } else {
+          return jsonResponse(200, {
+            sessionId: payload.sessionId ?? null,
+            botId: profile.id,
+            fenBefore,
+            fenAfter: bookBoard.fen(),
+            move: buildMovePayload(move),
+            analysis: buildBookAnalysis(bookMove),
+          });
+        }
+      }
+
+      const { lines, chosen } = await analyseWithEngine(profile, fenBefore);
+      const { board: afterBoard, move } = applyUciMove(fenBefore, chosen.move);
+      const analysis = buildEngineAnalysis(fenBefore, chosen, lines);
+
+      return jsonResponse(200, {
+        sessionId: payload.sessionId ?? null,
+        botId: profile.id,
+        fenBefore,
+        fenAfter: afterBoard.fen(),
+        move: buildMovePayload(move),
+        analysis,
+      });
+    }
+
+    return jsonResponse(404, { error: 'not_found' });
+  } catch (error) {
+    console.error('bots function error', error);
+    return jsonResponse(500, {
+      error: 'internal_error',
+      message: error instanceof Error ? error.message : 'unexpected',
+    });
+  }
+});

--- a/supabase/functions/bots/play.ts
+++ b/supabase/functions/bots/play.ts
@@ -1,0 +1,331 @@
+import { TextLineStream } from 'https://deno.land/std@0.224.0/streams/text_line_stream.ts';
+import { Chess } from 'npm:chess.js';
+import {
+  type BookLine,
+  type BotMoveSelection,
+  type BotProfileConfig,
+  type EngineConfig,
+  type EngineEvaluation,
+  type EngineRandomnessConfig,
+  type MultipvLine,
+  type OpeningBook,
+  type SelectedBookMove,
+} from './types.ts';
+
+const DEFAULT_LIMITS = Object.freeze({ moveTimeMs: 1000 });
+const DEFAULT_MULTIPV = 3;
+
+class StockfishProcess {
+  private process: Deno.ChildProcess;
+
+  private stdoutQueue: string[] = [];
+
+  private waiters: Array<(line: string) => void> = [];
+
+  private closed = false;
+
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+
+  private readonly encoder = new TextEncoder();
+
+  constructor(private readonly engine: EngineConfig) {
+    const binary = Deno.env.get('STOCKFISH_PATH') ?? './stockfish';
+    const command = new Deno.Command(binary, {
+      stdin: 'piped',
+      stdout: 'piped',
+      stderr: 'null',
+    });
+
+    this.process = command.spawn();
+    this.writer = this.process.stdin.getWriter();
+    const reader = this.process.stdout
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TextLineStream());
+    void this.consume(reader);
+  }
+
+  private async consume(stream: ReadableStream<string>) {
+    for await (const line of stream) {
+      if (this.waiters.length > 0) {
+        const waiter = this.waiters.shift();
+        waiter?.(line);
+      } else {
+        this.stdoutQueue.push(line);
+      }
+    }
+    this.closed = true;
+  }
+
+  private async readLine(): Promise<string> {
+    if (this.stdoutQueue.length > 0) {
+      return this.stdoutQueue.shift() as string;
+    }
+    if (this.closed) {
+      throw new Error('Stockfish process terminated unexpectedly');
+    }
+    return new Promise<string>((resolve) => this.waiters.push(resolve));
+  }
+
+  private async write(command: string) {
+    await this.writer.write(this.encoder.encode(`${command}\n`));
+  }
+
+  private async setOption(name: string, value: string | number | boolean) {
+    const formatted = typeof value === 'boolean' ? (value ? 'true' : 'false') : `${value}`;
+    await this.write(`setoption name ${name} value ${formatted}`);
+  }
+
+  async initialize() {
+    await this.write('uci');
+    let line = '';
+    do {
+      line = await this.readLine();
+    } while (!line.includes('uciok'));
+
+    const multiPv = this.engine.multiPv ?? DEFAULT_MULTIPV;
+    await this.setOption('MultiPV', Math.max(1, multiPv));
+
+    if (typeof this.engine.skillLevel === 'number') {
+      await this.setOption('Skill Level', this.engine.skillLevel);
+    }
+    if (typeof this.engine.uciElo === 'number') {
+      await this.setOption('UCI_Elo', this.engine.uciElo);
+    }
+    if (typeof this.engine.limitStrength === 'boolean') {
+      await this.setOption('UCI_LimitStrength', this.engine.limitStrength);
+    }
+    if (typeof this.engine.contempt === 'number') {
+      await this.setOption('Contempt', this.engine.contempt);
+    }
+    if (typeof this.engine.threads === 'number') {
+      await this.setOption('Threads', this.engine.threads);
+    }
+    if (typeof this.engine.hash === 'number') {
+      await this.setOption('Hash', this.engine.hash);
+    }
+
+    await this.write('isready');
+    do {
+      line = await this.readLine();
+    } while (!line.includes('readyok'));
+  }
+
+  async analysePosition(fen: string): Promise<MultipvLine[]> {
+    await this.write('ucinewgame');
+    await this.write(`position fen ${fen}`);
+
+    const limits = this.engine.limits ?? DEFAULT_LIMITS;
+    if (limits.nodes) {
+      await this.write(`go nodes ${limits.nodes}`);
+    } else if (limits.moveTimeMs) {
+      await this.write(`go movetime ${limits.moveTimeMs}`);
+    } else if (limits.depth) {
+      await this.write(`go depth ${limits.depth}`);
+    } else {
+      await this.write(`go movetime ${DEFAULT_LIMITS.moveTimeMs}`);
+    }
+
+    const lines = new Map<number, MultipvLine>();
+
+    while (true) {
+      const payload = await this.readLine();
+      if (payload.startsWith('info') && payload.includes('multipv')) {
+        const parsed = parseInfoLine(payload);
+        if (parsed) {
+          lines.set(parsed.multipv, parsed);
+        }
+      }
+      if (payload.startsWith('bestmove')) {
+        const match = payload.match(/bestmove (\S+)/);
+        if (match && !lines.has(1)) {
+          lines.set(1, {
+            multipv: 1,
+            move: match[1],
+            pv: [match[1]],
+            evaluation: { type: 'cp', value: 0 },
+          });
+        }
+        break;
+      }
+    }
+
+    return Array.from(lines.values()).sort((a, b) => a.multipv - b.multipv);
+  }
+
+  async dispose() {
+    try {
+      await this.write('quit');
+    } catch (_) {
+      // ignore errors when quitting
+    }
+    try {
+      await this.writer.close();
+    } catch (_) {
+      // ignore close errors
+    }
+    try {
+      this.process.kill('SIGTERM');
+    } catch (_) {
+      // ignore if already closed
+    }
+  }
+}
+
+function parseInfoLine(payload: string): MultipvLine | null {
+  const multipvMatch = payload.match(/ multipv (\d+)/);
+  if (!multipvMatch) return null;
+  const multipv = Number.parseInt(multipvMatch[1], 10);
+
+  const evaluation = extractEvaluation(payload);
+  if (!evaluation) return null;
+
+  const pvMatch = payload.match(/ pv (.*)$/);
+  if (!pvMatch) return null;
+  const pv = pvMatch[1].trim().split(/\s+/);
+  if (pv.length === 0) return null;
+
+  return {
+    multipv,
+    move: pv[0],
+    pv,
+    evaluation,
+  };
+}
+
+function extractEvaluation(payload: string): EngineEvaluation | null {
+  const mateMatch = payload.match(/ mate (-?\d+)/);
+  if (mateMatch) {
+    return { type: 'mate', value: Number.parseInt(mateMatch[1], 10) };
+  }
+  const cpMatch = payload.match(/ cp (-?\d+)/);
+  if (cpMatch) {
+    return { type: 'cp', value: Number.parseInt(cpMatch[1], 10) };
+  }
+  return null;
+}
+
+function evaluationToCentipawns(evaluation: EngineEvaluation): number {
+  if (evaluation.type === 'mate') {
+    return evaluation.value > 0 ? 100000 : -100000;
+  }
+  return evaluation.value;
+}
+
+function chooseCandidate(lines: MultipvLine[], randomness?: EngineRandomnessConfig): MultipvLine {
+  if (!randomness || !randomness.candidateWeights?.length) {
+    return lines[0];
+  }
+  if (lines.length === 0) {
+    throw new Error('Stockfish did not return candidate moves');
+  }
+
+  const topScore = evaluationToCentipawns(lines[0].evaluation);
+  if (!Number.isFinite(topScore) || Math.abs(topScore) >= 90000) {
+    return lines[0];
+  }
+
+  const eligible: Array<{ line: MultipvLine; weight: number }> = [];
+
+  randomness.candidateWeights.forEach((weight, index) => {
+    if (weight <= 0) return;
+    const line = lines[index];
+    if (!line) return;
+    const delta = Math.abs(evaluationToCentipawns(line.evaluation) - topScore);
+    if (delta <= randomness.maxDeltaCentipawns) {
+      eligible.push({ line, weight });
+    }
+  });
+
+  if (eligible.length === 0) {
+    return lines[0];
+  }
+
+  const totalWeight = eligible.reduce((sum, entry) => sum + entry.weight, 0);
+  let roll = Math.random() * totalWeight;
+  for (const entry of eligible) {
+    roll -= entry.weight;
+    if (roll <= 0) {
+      return entry.line;
+    }
+  }
+  return eligible[eligible.length - 1].line;
+}
+
+export function selectBookMove(book: OpeningBook | undefined, history: string[]): SelectedBookMove | null {
+  if (!book?.lines?.length) {
+    return null;
+  }
+
+  const candidates: Array<{ move: string; weight: number; line: BookLine }> = [];
+
+  for (const line of book.lines) {
+    const moves = line.moves ?? [];
+    if (moves.length <= history.length) {
+      continue;
+    }
+    let matches = true;
+    for (let ply = 0; ply < history.length; ply++) {
+      if (moves[ply]?.toLowerCase() !== history[ply]?.toLowerCase()) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) continue;
+    const nextMove = moves[history.length];
+    if (!nextMove) continue;
+    const weight = line.weight ?? 1;
+    candidates.push({ move: nextMove, weight, line });
+  }
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const total = candidates.reduce((sum, entry) => sum + entry.weight, 0);
+  let roll = Math.random() * total;
+  for (const entry of candidates) {
+    roll -= entry.weight;
+    if (roll <= 0) {
+      return { move: entry.move, line: entry.line };
+    }
+  }
+  const last = candidates[candidates.length - 1];
+  return { move: last.move, line: last.line };
+}
+
+export async function analyseWithEngine(profile: BotProfileConfig, fen: string): Promise<BotMoveSelection> {
+  const engineConfig: EngineConfig = profile.style.engine ?? {};
+  const process = new StockfishProcess(engineConfig);
+  try {
+    await process.initialize();
+    const lines = await process.analysePosition(fen);
+    if (!lines.length) {
+      throw new Error('Engine produced no candidate lines');
+    }
+    const chosen = chooseCandidate(lines, engineConfig.randomness);
+    return { lines, chosen };
+  } finally {
+    await process.dispose();
+  }
+}
+
+export function applyUciMove(fen: string, uci: string) {
+  const board = new Chess();
+  board.load(fen);
+  const move = board.move(uci, { sloppy: true });
+  if (!move) {
+    throw new Error(`Failed to apply move ${uci} to position ${fen}`);
+  }
+  return { board, move };
+}
+
+export function pvToSanSequence(fen: string, pv: string[]): string[] {
+  const board = new Chess();
+  board.load(fen);
+  const sequence: string[] = [];
+  for (const uci of pv) {
+    const move = board.move(uci, { sloppy: true });
+    sequence.push(move?.san ?? uci);
+  }
+  return sequence;
+}

--- a/supabase/functions/bots/profiles.ts
+++ b/supabase/functions/bots/profiles.ts
@@ -1,0 +1,22 @@
+import beginner from './profiles/beginner.json' assert { type: 'json' };
+import tactician from './profiles/tactician.json' assert { type: 'json' };
+import gambit from './profiles/gambit.json' assert { type: 'json' };
+import aggressive from './profiles/aggressive.json' assert { type: 'json' };
+import solid from './profiles/solid.json' assert { type: 'json' };
+import zen from './profiles/zen.json' assert { type: 'json' };
+import type { BotProfileConfig } from './types.ts';
+
+const profiles = [
+  beginner as BotProfileConfig,
+  tactician as BotProfileConfig,
+  gambit as BotProfileConfig,
+  aggressive as BotProfileConfig,
+  solid as BotProfileConfig,
+  zen as BotProfileConfig,
+];
+
+export const BOT_PROFILES: BotProfileConfig[] = profiles;
+
+export function getProfileById(id: string): BotProfileConfig | undefined {
+  return profiles.find((profile) => profile.id === id);
+}

--- a/supabase/functions/bots/profiles/aggressive.json
+++ b/supabase/functions/bots/profiles/aggressive.json
@@ -1,0 +1,48 @@
+{
+  "id": "bb61eeb3-c0f7-459e-a2cd-d45d72ba2ab6",
+  "name": "Attaquant Foudroyant",
+  "elo_target": 2050,
+  "style": {
+    "label": "Agressif",
+    "personality": "Toujours en quête de complications, il ouvre les colonnes contre le roi adverse",
+    "description": "Un maître des attaques directes: l'Attaquant Foudroyant privilégie les lignes aiguës, sacrifie du matériel pour l'initiative et attaque sur les cases faibles.",
+    "traits": [
+      "Attaques sur le roi",
+      "Pression permanente",
+      "Refuse les finales calmes"
+    ],
+    "engine": {
+      "skillLevel": 14,
+      "uciElo": 2050,
+      "limitStrength": true,
+      "multiPv": 4,
+      "contempt": 15,
+      "randomness": {
+        "candidateWeights": [0.75, 0.2, 0.05],
+        "maxDeltaCentipawns": 45
+      },
+      "limits": {
+        "moveTimeMs": 1100
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Dragon accéléré",
+        "moves": ["e4", "c5", "Nf3", "Nc6", "d4", "cxd4", "Nxd4", "g6", "Nc3", "Bg7", "Be3", "Nf6", "Qd2", "O-O", "O-O-O"],
+        "weight": 4
+      },
+      {
+        "name": "Attaque de l'indienne du roi",
+        "moves": ["d4", "Nf6", "c4", "g6", "Nc3", "Bg7", "e4", "d6", "f3", "O-O", "Be3", "Nc6", "Qd2", "a6", "O-O-O"],
+        "weight": 3
+      },
+      {
+        "name": "Gambit Evans",
+        "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "b4", "Bxb4", "c3", "Ba5", "d4", "exd4", "O-O"],
+        "weight": 3
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/profiles/beginner.json
+++ b/supabase/functions/bots/profiles/beginner.json
@@ -1,0 +1,48 @@
+{
+  "id": "e458fd2b-ada4-47f9-bc34-4bc16e631fbb",
+  "name": "Apprenti",
+  "elo_target": 450,
+  "style": {
+    "label": "Débutant",
+    "personality": "Joueur prudent qui apprend encore les schémas de base",
+    "description": "Idéal pour les premières parties: l'Apprenti commet des imprécisions, développe lentement ses pièces et accepte volontiers les échanges simples.",
+    "traits": [
+      "Priorité aux coups naturels",
+      "Peu de tactiques",
+      "Favorise les structures symétriques"
+    ],
+    "engine": {
+      "skillLevel": 1,
+      "uciElo": 600,
+      "limitStrength": true,
+      "multiPv": 2,
+      "contempt": -10,
+      "randomness": {
+        "candidateWeights": [0.6, 0.3, 0.1],
+        "maxDeltaCentipawns": 120
+      },
+      "limits": {
+        "moveTimeMs": 350
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Italienne lente",
+        "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "d3", "d6"],
+        "weight": 4
+      },
+      {
+        "name": "Giuoco Pianissimo",
+        "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "d3", "Bc5"],
+        "weight": 3
+      },
+      {
+        "name": "Ouverture du pion dame simplifiée",
+        "moves": ["d4", "d5", "Nf3", "Nf6", "e3", "e6", "Bd3", "Bd6"],
+        "weight": 3
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/profiles/gambit.json
+++ b/supabase/functions/bots/profiles/gambit.json
@@ -1,0 +1,48 @@
+{
+  "id": "bd89f893-a075-4942-9ad2-553b96aaf01e",
+  "name": "Architecte de Gambits",
+  "elo_target": 1550,
+  "style": {
+    "label": "Gambits",
+    "personality": "Adore sacrifier des pions pour l'activité et attaque sans relâche",
+    "description": "Ce profil prend des risques calculés, crée des positions déséquilibrées et punit les défenses passives. Préparez-vous à défendre avec précision!",
+    "traits": [
+      "Sacrifices de pions thématiques",
+      "Initiative permanente",
+      "Recherche de déséquilibres"
+    ],
+    "engine": {
+      "skillLevel": 10,
+      "uciElo": 1500,
+      "limitStrength": true,
+      "multiPv": 4,
+      "contempt": 5,
+      "randomness": {
+        "candidateWeights": [0.65, 0.25, 0.1],
+        "maxDeltaCentipawns": 60
+      },
+      "limits": {
+        "moveTimeMs": 900
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Gambit roi accepté",
+        "moves": ["e4", "e5", "f4", "exf4", "Nf3", "g5", "h4", "g4", "Ne5"],
+        "weight": 4
+      },
+      {
+        "name": "Gambit de Budapest",
+        "moves": ["d4", "Nf6", "c4", "e5", "dxe5", "Ng4", "Nf3", "Nc6", "Bf4", "Bb4+"],
+        "weight": 3
+      },
+      {
+        "name": "Gambit Benko",
+        "moves": ["d4", "Nf6", "c4", "c5", "d5", "b5", "cxb5", "a6", "bxa6", "g6", "Nc3", "Bg7"],
+        "weight": 3
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/profiles/solid.json
+++ b/supabase/functions/bots/profiles/solid.json
@@ -1,0 +1,48 @@
+{
+  "id": "ae5295e1-8615-4e50-b591-b2c5a077d089",
+  "name": "Mur de Granit",
+  "elo_target": 2400,
+  "style": {
+    "label": "Solide",
+    "personality": "Patient, pragmatique et prêt à jouer les finales longues",
+    "description": "Un mur défensif difficile à percer. Il neutralise les attaques, améliore ses pièces méthodiquement et exploite les faiblesses adverses en finale.",
+    "traits": [
+      "Stratégie positionnelle",
+      "Réduit les risques",
+      "Convertit les avantages avec précision"
+    ],
+    "engine": {
+      "skillLevel": 17,
+      "uciElo": 2400,
+      "limitStrength": true,
+      "multiPv": 4,
+      "contempt": 0,
+      "randomness": {
+        "candidateWeights": [0.85, 0.1, 0.05],
+        "maxDeltaCentipawns": 30
+      },
+      "limits": {
+        "moveTimeMs": 1300
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Espagnole fermée",
+        "moves": ["e4", "e5", "Nf3", "Nc6", "Bb5", "a6", "Ba4", "Nf6", "O-O", "Be7", "Re1", "b5", "Bb3", "d6", "c3", "O-O"],
+        "weight": 5
+      },
+      {
+        "name": "Slav classique",
+        "moves": ["d4", "d5", "c4", "c6", "Nf3", "Nf6", "Nc3", "dxc4", "a4", "Bf5", "e3", "e6", "Bxc4", "Bb4", "O-O"],
+        "weight": 3
+      },
+      {
+        "name": "Défense Caro-Kann solide",
+        "moves": ["e4", "c6", "d4", "d5", "Nc3", "dxe4", "Nxe4", "Bf5", "Ng3", "Bg6", "Nf3", "Nd7", "h4", "h6"],
+        "weight": 2
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/profiles/tactician.json
+++ b/supabase/functions/bots/profiles/tactician.json
@@ -1,0 +1,48 @@
+{
+  "id": "94cf293e-56af-4dbb-b2db-339fb43b5f51",
+  "name": "Capitaine Tactique",
+  "elo_target": 1100,
+  "style": {
+    "label": "Tacticien",
+    "personality": "Cherche les fourchettes et tactiques simples, mais peut oublier sa défense",
+    "description": "Un adversaire idéal pour progresser: il développe ses pièces rapidement, prépare des attaques sur le roi et peut sacrifier du matériel pour l'initiative.",
+    "traits": [
+      "Préférence pour les positions ouvertes",
+      "Menaces tactiques directes",
+      "Parfois impatient en finale"
+    ],
+    "engine": {
+      "skillLevel": 5,
+      "uciElo": 1100,
+      "limitStrength": true,
+      "multiPv": 3,
+      "contempt": 0,
+      "randomness": {
+        "candidateWeights": [0.7, 0.2, 0.1],
+        "maxDeltaCentipawns": 80
+      },
+      "limits": {
+        "moveTimeMs": 650
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Sicilienne classique",
+        "moves": ["e4", "c5", "Nf3", "d6", "d4", "cxd4", "Nxd4", "Nf6", "Nc3", "Nc6"],
+        "weight": 5
+      },
+      {
+        "name": "Variante d'avance française",
+        "moves": ["e4", "e6", "d4", "d5", "e5", "c5", "c3", "Nc6", "Nf3", "Qb6"],
+        "weight": 3
+      },
+      {
+        "name": "Défense Scandinave active",
+        "moves": ["e4", "d5", "exd5", "Qxd5", "Nc3", "Qa5", "d4", "c6"],
+        "weight": 2
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/profiles/zen.json
+++ b/supabase/functions/bots/profiles/zen.json
@@ -1,0 +1,47 @@
+{
+  "id": "e747b364-5dae-4d65-8efb-101194646da1",
+  "name": "Zen Grand Maître",
+  "elo_target": 2850,
+  "style": {
+    "label": "Équilibré",
+    "personality": "Calme et clinique, choisit les lignes les plus précises et attend la moindre imprécision",
+    "description": "Le bot ultime: il combine prophylaxie, calcul profond et sens stratégique. Ses coups semblent simples mais cachent une compréhension magistrale.",
+    "traits": [
+      "Calcul profond",
+      "Prophylaxie constante",
+      "Conversion technique irréprochable"
+    ],
+    "engine": {
+      "skillLevel": 20,
+      "limitStrength": false,
+      "multiPv": 5,
+      "contempt": -5,
+      "randomness": {
+        "candidateWeights": [0.9, 0.08, 0.02],
+        "maxDeltaCentipawns": 18
+      },
+      "limits": {
+        "moveTimeMs": 1800
+      }
+    }
+  },
+  "book": {
+    "lines": [
+      {
+        "name": "Nimzo-Indienne Rubinstein",
+        "moves": ["d4", "Nf6", "c4", "e6", "Nc3", "Bb4", "e3", "O-O", "Bd3", "d5", "Nf3", "c5", "O-O", "dxc4", "Bxc4"],
+        "weight": 4
+      },
+      {
+        "name": "Catalane fermée",
+        "moves": ["d4", "Nf6", "c4", "e6", "g3", "d5", "Bg2", "Be7", "Nf3", "O-O", "O-O", "dxc4", "Qc2", "a6", "a4"],
+        "weight": 3
+      },
+      {
+        "name": "Début anglais symétrique",
+        "moves": ["c4", "c5", "Nc3", "Nc6", "g3", "g6", "Bg2", "Bg7", "Nf3", "e5", "O-O", "Nge7", "a3"],
+        "weight": 3
+      }
+    ]
+  }
+}

--- a/supabase/functions/bots/types.ts
+++ b/supabase/functions/bots/types.ts
@@ -1,0 +1,72 @@
+export type EvaluationType = 'cp' | 'mate';
+
+export interface EngineEvaluation {
+  type: EvaluationType;
+  value: number;
+}
+
+export interface EngineRandomnessConfig {
+  candidateWeights: number[];
+  maxDeltaCentipawns: number;
+}
+
+export interface EngineLimitsConfig {
+  moveTimeMs?: number;
+  nodes?: number;
+  depth?: number;
+}
+
+export interface EngineConfig {
+  skillLevel?: number;
+  uciElo?: number;
+  limitStrength?: boolean;
+  multiPv?: number;
+  contempt?: number;
+  threads?: number;
+  hash?: number;
+  randomness?: EngineRandomnessConfig;
+  limits?: EngineLimitsConfig;
+}
+
+export interface BookLine {
+  name?: string;
+  moves: string[];
+  weight?: number;
+}
+
+export interface OpeningBook {
+  lines: BookLine[];
+}
+
+export interface SelectedBookMove {
+  move: string;
+  line?: BookLine;
+}
+
+export interface BotStyle {
+  label: string;
+  personality: string;
+  description: string;
+  traits: string[];
+  engine?: EngineConfig;
+}
+
+export interface BotProfileConfig {
+  id: string;
+  name: string;
+  elo_target: number;
+  style: BotStyle;
+  book: OpeningBook;
+}
+
+export interface MultipvLine {
+  multipv: number;
+  move: string;
+  pv: string[];
+  evaluation: EngineEvaluation;
+}
+
+export interface BotMoveSelection {
+  lines: MultipvLine[];
+  chosen: MultipvLine;
+}

--- a/supabase/migrations/20251102000000_create_bot_profiles.sql
+++ b/supabase/migrations/20251102000000_create_bot_profiles.sql
@@ -1,0 +1,303 @@
+create table if not exists public.bot_profiles (
+  id uuid primary key default gen_random_uuid(),
+  name text unique not null,
+  elo_target int not null,
+  style jsonb not null,
+  book jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+insert into public.bot_profiles (id, name, elo_target, style, book)
+values
+  (
+    'e458fd2b-ada4-47f9-bc34-4bc16e631fbb',
+    'Apprenti',
+    450,
+    '{
+      "label": "Débutant",
+      "personality": "Joueur prudent qui apprend encore les schémas de base",
+      "description": "Idéal pour les premières parties: l''Apprenti commet des imprécisions, développe lentement ses pièces et accepte volontiers les échanges simples.",
+      "traits": [
+        "Priorité aux coups naturels",
+        "Peu de tactiques",
+        "Favorise les structures symétriques"
+      ],
+      "engine": {
+        "skillLevel": 1,
+        "uciElo": 600,
+        "limitStrength": true,
+        "multiPv": 2,
+        "contempt": -10,
+        "randomness": {
+          "candidateWeights": [0.6, 0.3, 0.1],
+          "maxDeltaCentipawns": 120
+        },
+        "limits": {
+          "moveTimeMs": 350
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Italienne lente",
+          "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "d3", "d6"],
+          "weight": 4
+        },
+        {
+          "name": "Giuoco Pianissimo",
+          "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "d3", "Bc5"],
+          "weight": 3
+        },
+        {
+          "name": "Ouverture du pion dame simplifiée",
+          "moves": ["d4", "d5", "Nf3", "Nf6", "e3", "e6", "Bd3", "Bd6"],
+          "weight": 3
+        }
+      ]
+    }'::jsonb
+  ),
+  (
+    '94cf293e-56af-4dbb-b2db-339fb43b5f51',
+    'Capitaine Tactique',
+    1100,
+    '{
+      "label": "Tacticien",
+      "personality": "Cherche les fourchettes et tactiques simples, mais peut oublier sa défense",
+      "description": "Un adversaire idéal pour progresser: il développe ses pièces rapidement, prépare des attaques sur le roi et peut sacrifier du matériel pour l''initiative.",
+      "traits": [
+        "Préférence pour les positions ouvertes",
+        "Menaces tactiques directes",
+        "Parfois impatient en finale"
+      ],
+      "engine": {
+        "skillLevel": 5,
+        "uciElo": 1100,
+        "limitStrength": true,
+        "multiPv": 3,
+        "contempt": 0,
+        "randomness": {
+          "candidateWeights": [0.7, 0.2, 0.1],
+          "maxDeltaCentipawns": 80
+        },
+        "limits": {
+          "moveTimeMs": 650
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Sicilienne classique",
+          "moves": ["e4", "c5", "Nf3", "d6", "d4", "cxd4", "Nxd4", "Nf6", "Nc3", "Nc6"],
+          "weight": 5
+        },
+        {
+          "name": "Variante d'avance française",
+          "moves": ["e4", "e6", "d4", "d5", "e5", "c5", "c3", "Nc6", "Nf3", "Qb6"],
+          "weight": 3
+        },
+        {
+          "name": "Défense Scandinave active",
+          "moves": ["e4", "d5", "exd5", "Qxd5", "Nc3", "Qa5", "d4", "c6"],
+          "weight": 2
+        }
+      ]
+    }'::jsonb
+  ),
+  (
+    'bd89f893-a075-4942-9ad2-553b96aaf01e',
+    'Architecte de Gambits',
+    1550,
+    '{
+      "label": "Gambits",
+      "personality": "Adore sacrifier des pions pour l'activité et attaque sans relâche",
+      "description": "Ce profil prend des risques calculés, crée des positions déséquilibrées et punit les défenses passives. Préparez-vous à défendre avec précision!",
+      "traits": [
+        "Sacrifices de pions thématiques",
+        "Initiative permanente",
+        "Recherche de déséquilibres"
+      ],
+      "engine": {
+        "skillLevel": 10,
+        "uciElo": 1500,
+        "limitStrength": true,
+        "multiPv": 4,
+        "contempt": 5,
+        "randomness": {
+          "candidateWeights": [0.65, 0.25, 0.1],
+          "maxDeltaCentipawns": 60
+        },
+        "limits": {
+          "moveTimeMs": 900
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Gambit roi accepté",
+          "moves": ["e4", "e5", "f4", "exf4", "Nf3", "g5", "h4", "g4", "Ne5"],
+          "weight": 4
+        },
+        {
+          "name": "Gambit de Budapest",
+          "moves": ["d4", "Nf6", "c4", "e5", "dxe5", "Ng4", "Nf3", "Nc6", "Bf4", "Bb4+"],
+          "weight": 3
+        },
+        {
+          "name": "Gambit Benko",
+          "moves": ["d4", "Nf6", "c4", "c5", "d5", "b5", "cxb5", "a6", "bxa6", "g6", "Nc3", "Bg7"],
+          "weight": 3
+        }
+      ]
+    }'::jsonb
+  ),
+  (
+    'bb61eeb3-c0f7-459e-a2cd-d45d72ba2ab6',
+    'Attaquant Foudroyant',
+    2050,
+    '{
+      "label": "Agressif",
+      "personality": "Toujours en quête de complications, il ouvre les colonnes contre le roi adverse",
+      "description": "Un maître des attaques directes: l''Attaquant Foudroyant privilégie les lignes aiguës, sacrifie du matériel pour l''initiative et attaque sur les cases faibles.",
+      "traits": [
+        "Attaques sur le roi",
+        "Pression permanente",
+        "Refuse les finales calmes"
+      ],
+      "engine": {
+        "skillLevel": 14,
+        "uciElo": 2050,
+        "limitStrength": true,
+        "multiPv": 4,
+        "contempt": 15,
+        "randomness": {
+          "candidateWeights": [0.75, 0.2, 0.05],
+          "maxDeltaCentipawns": 45
+        },
+        "limits": {
+          "moveTimeMs": 1100
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Dragon accéléré",
+          "moves": ["e4", "c5", "Nf3", "Nc6", "d4", "cxd4", "Nxd4", "g6", "Nc3", "Bg7", "Be3", "Nf6", "Qd2", "O-O", "O-O-O"],
+          "weight": 4
+        },
+        {
+          "name": "Attaque de l'indienne du roi",
+          "moves": ["d4", "Nf6", "c4", "g6", "Nc3", "Bg7", "e4", "d6", "f3", "O-O", "Be3", "Nc6", "Qd2", "a6", "O-O-O"],
+          "weight": 3
+        },
+        {
+          "name": "Gambit Evans",
+          "moves": ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "b4", "Bxb4", "c3", "Ba5", "d4", "exd4", "O-O"],
+          "weight": 3
+        }
+      ]
+    }'::jsonb
+  ),
+  (
+    'ae5295e1-8615-4e50-b591-b2c5a077d089',
+    'Mur de Granit',
+    2400,
+    '{
+      "label": "Solide",
+      "personality": "Patient, pragmatique et prêt à jouer les finales longues",
+      "description": "Un mur défensif difficile à percer. Il neutralise les attaques, améliore ses pièces méthodiquement et exploite les faiblesses adverses en finale.",
+      "traits": [
+        "Stratégie positionnelle",
+        "Réduit les risques",
+        "Convertit les avantages avec précision"
+      ],
+      "engine": {
+        "skillLevel": 17,
+        "uciElo": 2400,
+        "limitStrength": true,
+        "multiPv": 4,
+        "contempt": 0,
+        "randomness": {
+          "candidateWeights": [0.85, 0.1, 0.05],
+          "maxDeltaCentipawns": 30
+        },
+        "limits": {
+          "moveTimeMs": 1300
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Espagnole fermée",
+          "moves": ["e4", "e5", "Nf3", "Nc6", "Bb5", "a6", "Ba4", "Nf6", "O-O", "Be7", "Re1", "b5", "Bb3", "d6", "c3", "O-O"],
+          "weight": 5
+        },
+        {
+          "name": "Slav classique",
+          "moves": ["d4", "d5", "c4", "c6", "Nf3", "Nf6", "Nc3", "dxc4", "a4", "Bf5", "e3", "e6", "Bxc4", "Bb4", "O-O"],
+          "weight": 3
+        },
+        {
+          "name": "Défense Caro-Kann solide",
+          "moves": ["e4", "c6", "d4", "d5", "Nc3", "dxe4", "Nxe4", "Bf5", "Ng3", "Bg6", "Nf3", "Nd7", "h4", "h6"],
+          "weight": 2
+        }
+      ]
+    }'::jsonb
+  ),
+  (
+    'e747b364-5dae-4d65-8efb-101194646da1',
+    'Zen Grand Maître',
+    2850,
+    '{
+      "label": "Équilibré",
+      "personality": "Calme et clinique, choisit les lignes les plus précises et attend la moindre imprécision",
+      "description": "Le bot ultime: il combine prophylaxie, calcul profond et sens stratégique. Ses coups semblent simples mais cachent une compréhension magistrale.",
+      "traits": [
+        "Calcul profond",
+        "Prophylaxie constante",
+        "Conversion technique irréprochable"
+      ],
+      "engine": {
+        "skillLevel": 20,
+        "limitStrength": false,
+        "multiPv": 5,
+        "contempt": -5,
+        "randomness": {
+          "candidateWeights": [0.9, 0.08, 0.02],
+          "maxDeltaCentipawns": 18
+        },
+        "limits": {
+          "moveTimeMs": 1800
+        }
+      }
+    }'::jsonb,
+    '{
+      "lines": [
+        {
+          "name": "Nimzo-Indienne Rubinstein",
+          "moves": ["d4", "Nf6", "c4", "e6", "Nc3", "Bb4", "e3", "O-O", "Bd3", "d5", "Nf3", "c5", "O-O", "dxc4", "Bxc4"],
+          "weight": 4
+        },
+        {
+          "name": "Catalane fermée",
+          "moves": ["d4", "Nf6", "c4", "e6", "g3", "d5", "Bg2", "Be7", "Nf3", "O-O", "O-O", "dxc4", "Qc2", "a6", "a4"],
+          "weight": 3
+        },
+        {
+          "name": "Début anglais symétrique",
+          "moves": ["c4", "c5", "Nc3", "Nc6", "g3", "g6", "Bg2", "Bg7", "Nf3", "e5", "O-O", "Nge7", "a3"],
+          "weight": 3
+        }
+      ]
+    }'::jsonb
+  )
+on conflict (id) do update set
+  name = excluded.name,
+  elo_target = excluded.elo_target,
+  style = excluded.style,
+  book = excluded.book;


### PR DESCRIPTION
## Summary
- implement Supabase bots edge function with Stockfish tuning, book selection, and new/move endpoints
- seed Supabase with multi-style bot profiles and expose picker/board components for UI integration
- add shared bot client utilities for calling the new edge APIs from the frontend

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcbc9cbe1483239a4135ad908a0eba