### PR TITLE
Add cloud Stockfish live evaluation streaming

### DIFF
--- a/src/features/analysis/LiveEvalBadge.tsx
+++ b/src/features/analysis/LiveEvalBadge.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Chess } from "chess.js";
+import { Activity, AlertTriangle, Loader2, WifiOff } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface EngineEvaluation {
+  type: "cp" | "mate";
+  value: number;
+}
+
+interface EvalPayload {
+  type: "eval";
+  ply: number;
+  bestMove: string;
+  evaluation: EngineEvaluation;
+  depth: number;
+  engineTimeMs: number;
+  fen: string;
+}
+
+interface ReadyPayload {
+  type: "ready";
+  depth: number;
+  threads: number;
+}
+
+interface ErrorPayload {
+  type: "error";
+  message: string;
+}
+
+type ServerMessage = EvalPayload | ReadyPayload | ErrorPayload;
+
+type LiveEvalStatus =
+  | "idle"
+  | "connecting"
+  | "ready"
+  | "error"
+  | "disconnected";
+
+export interface LiveEvalBadgeProps {
+  fen: string;
+  ply?: number;
+  enabled?: boolean;
+  perspective?: "w" | "b";
+  serverUrl?: string;
+  className?: string;
+}
+
+interface PendingRequest {
+  fen: string;
+  ply: number;
+  enqueuedAt: number;
+}
+
+interface LatestEvaluation {
+  payload: EvalPayload;
+  latencyMs?: number;
+}
+
+const DEFAULT_SERVER_PATH = "/functions/v1/live-eval";
+
+function buildSocketUrl(serverUrl: string): string {
+  if (serverUrl.startsWith("ws://") || serverUrl.startsWith("wss://")) {
+    return serverUrl;
+  }
+  if (serverUrl.startsWith("https://")) {
+    return `wss://${serverUrl.slice("https://".length)}`;
+  }
+  if (serverUrl.startsWith("http://")) {
+    return `ws://${serverUrl.slice("http://".length)}`;
+  }
+  if (typeof window === "undefined") {
+    return serverUrl;
+  }
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const host = window.location.host;
+  if (serverUrl.startsWith("/")) {
+    return `${protocol}//${host}${serverUrl}`;
+  }
+  return `${protocol}//${host}/${serverUrl}`;
+}
+
+function derivePlyFromFen(fen: string): number {
+  const parts = fen.trim().split(/\s+/);
+  if (parts.length < 6) return 0;
+  const fullmove = Number.parseInt(parts[5], 10);
+  if (!Number.isFinite(fullmove) || fullmove <= 0) return 0;
+  const sideToMove = parts[1] === "b" ? 1 : 0;
+  return (fullmove - 1) * 2 + sideToMove;
+}
+
+function formatEvaluation(
+  evaluation: EngineEvaluation,
+  fen: string,
+  perspective: "w" | "b"
+): { label: string; numeric?: number } {
+  const parts = fen.trim().split(/\s+/);
+  const sideToMove = parts[1] === "b" ? "b" : "w";
+  const perspectiveSign = perspective === "w" ? 1 : -1;
+  if (evaluation.type === "mate") {
+    const mateFromWhite = sideToMove === "w" ? evaluation.value : -evaluation.value;
+    const oriented = mateFromWhite * perspectiveSign;
+    const suffix = `#${Math.abs(oriented)}`;
+    return { label: oriented >= 0 ? suffix : `-${suffix}` };
+  }
+  const cpFromWhite = sideToMove === "w" ? evaluation.value : -evaluation.value;
+  const oriented = (cpFromWhite / 100) * perspectiveSign;
+  const label = `${oriented >= 0 ? "+" : ""}${oriented.toFixed(2)}`;
+  return { label, numeric: oriented };
+}
+
+function formatBestMove(fen: string, bestMove: string): string {
+  try {
+    const chess = new Chess(fen);
+    const moves = chess.moves({ verbose: true }) as Array<{
+      from: string;
+      to: string;
+      san: string;
+      promotion?: string;
+    }>;
+    const match = moves.find((move) => {
+      const promotion = move.promotion ? move.promotion : "";
+      return `${move.from}${move.to}${promotion}`.toLowerCase() === bestMove.toLowerCase();
+    });
+    return match?.san ?? bestMove;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("Failed to format best move", error);
+    }
+    return bestMove;
+  }
+}
+
+export function LiveEvalBadge({
+  fen,
+  ply,
+  enabled = true,
+  perspective = "w",
+  serverUrl = DEFAULT_SERVER_PATH,
+  className,
+}: LiveEvalBadgeProps) {
+  const [status, setStatus] = useState<LiveEvalStatus>(() => (enabled ? "connecting" : "idle"));
+  const [engineInfo, setEngineInfo] = useState<ReadyPayload | null>(null);
+  const [latest, setLatest] = useState<LatestEvaluation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [connectionToken, setConnectionToken] = useState(0);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const queueRef = useRef<PendingRequest | null>(null);
+  const inflightRef = useRef<PendingRequest | null>(null);
+  const flushRef = useRef<() => void>(() => undefined);
+  const reconnectTimeoutRef = useRef<number | undefined>(undefined);
+
+  const effectivePly = useMemo(() => {
+    if (typeof ply === "number" && Number.isFinite(ply)) {
+      return ply;
+    }
+    return derivePlyFromFen(fen);
+  }, [fen, ply]);
+
+  useEffect(() => {
+    if (typeof reconnectTimeoutRef.current === "number") {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = undefined;
+    }
+
+    if (!enabled) {
+      setStatus("idle");
+      setEngineInfo(null);
+      setLatest(null);
+      setError(null);
+      if (wsRef.current &&
+        (wsRef.current.readyState === WebSocket.OPEN || wsRef.current.readyState === WebSocket.CONNECTING)) {
+        wsRef.current.close(1000, "Live eval disabled");
+      }
+      wsRef.current = null;
+      queueRef.current = null;
+      inflightRef.current = null;
+      return;
+    }
+
+    setStatus("connecting");
+    setError(null);
+    const url = buildSocketUrl(serverUrl);
+    let closed = false;
+    const socket = new WebSocket(url);
+    wsRef.current = socket;
+    queueRef.current = null;
+    inflightRef.current = null;
+
+    const flushQueue = () => {
+      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      if (inflightRef.current || !queueRef.current) {
+        return;
+      }
+      const next = queueRef.current;
+      queueRef.current = null;
+      inflightRef.current = { ...next, enqueuedAt: performance.now() };
+      wsRef.current.send(
+        JSON.stringify({
+          type: "fen",
+          fen: next.fen,
+          ply: next.ply,
+        })
+      );
+    };
+
+    flushRef.current = flushQueue;
+
+    socket.onopen = () => {
+      if (closed) return;
+      flushQueue();
+    };
+
+    socket.onmessage = (event) => {
+      if (closed) return;
+      if (typeof event.data !== "string") return;
+      let payload: ServerMessage | null = null;
+        try {
+          payload = JSON.parse(event.data) as ServerMessage;
+        } catch (parseError) {
+          if (import.meta.env.DEV) {
+            console.warn("live-eval: failed to parse payload", parseError);
+          }
+          return;
+        }
+
+      if (!payload) return;
+
+      if (payload.type === "ready") {
+        setEngineInfo(payload);
+        setStatus("ready");
+        return;
+      }
+
+      if (payload.type === "error") {
+        setStatus("error");
+        setError(payload.message);
+        return;
+      }
+
+      if (payload.type === "eval") {
+        const inflight = inflightRef.current;
+        const latency = inflight ? performance.now() - inflight.enqueuedAt : undefined;
+        inflightRef.current = null;
+        setLatest({ payload, latencyMs: latency });
+        flushQueue();
+        return;
+      }
+    };
+
+    socket.onerror = (event) => {
+      console.error("live-eval websocket error", event);
+      if (!closed) {
+        setStatus("error");
+        setError("Connexion au serveur d'évaluation perdue");
+      }
+    };
+
+    socket.onclose = () => {
+      if (closed) return;
+      closed = true;
+      inflightRef.current = null;
+      flushRef.current = () => undefined;
+      if (enabled) {
+        setStatus((previous) => (previous === "error" ? previous : "disconnected"));
+        reconnectTimeoutRef.current = window.setTimeout(() => {
+          setConnectionToken((value) => value + 1);
+        }, 600);
+      } else {
+        setStatus("idle");
+      }
+    };
+
+    return () => {
+      closed = true;
+      flushRef.current = () => undefined;
+      if (
+        socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING
+      ) {
+        socket.close(1000, "Component unmounted");
+      }
+      wsRef.current = null;
+      queueRef.current = null;
+      inflightRef.current = null;
+      if (typeof reconnectTimeoutRef.current === "number") {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = undefined;
+      }
+    };
+  }, [enabled, serverUrl, connectionToken]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!fen) return;
+    const request: PendingRequest = {
+      fen,
+      ply: effectivePly,
+      enqueuedAt: performance.now(),
+    };
+    queueRef.current = request;
+    flushRef.current();
+  }, [fen, effectivePly, enabled]);
+
+  const evaluationSummary = useMemo(() => {
+    if (!latest) {
+      if (status === "connecting") {
+        return "Connexion au cloud";
+      }
+      if (status === "ready") {
+        return engineInfo ? `Profondeur ${engineInfo.depth}` : "Cloud prêt";
+      }
+      return null;
+    }
+
+    const { payload, latencyMs } = latest;
+    const evaluation = formatEvaluation(payload.evaluation, payload.fen, perspective);
+    const bestMove = payload.bestMove ? formatBestMove(payload.fen, payload.bestMove) : null;
+    const parts: string[] = [];
+    parts.push(evaluation.label);
+    if (bestMove) {
+      parts.push(bestMove);
+    }
+    const latency = latencyMs ?? payload.engineTimeMs;
+    if (typeof latency === "number" && Number.isFinite(latency)) {
+      parts.push(`${Math.round(latency)} ms`);
+    }
+    return parts.join(" • ");
+  }, [engineInfo, latest, perspective, status]);
+
+  const icon = useMemo(() => {
+    if (status === "error") {
+      return <AlertTriangle className="w-3 h-3" />;
+    }
+    if (status === "connecting" || status === "disconnected") {
+      return <Loader2 className="w-3 h-3 animate-spin" />;
+    }
+    return <Activity className="w-3 h-3" />;
+  }, [status]);
+
+  const badgeVariant = status === "error" ? "destructive" : "outline";
+  const label = (() => {
+    if (status === "idle") {
+      return "Éval cloud désactivée";
+    }
+    if (status === "disconnected") {
+      return "Reconnexion";
+    }
+    if (status === "error") {
+      return error ?? "Erreur";
+    }
+    if (evaluationSummary) {
+      return evaluationSummary;
+    }
+    if (status === "connecting") {
+      return "Connexion au cloud";
+    }
+    return "Cloud prêt";
+  })();
+
+  return (
+    <Badge variant={badgeVariant} className={cn("flex items-center gap-1 text-xs", className)}>
+      {status === "idle" ? <WifiOff className="w-3 h-3" /> : icon}
+      <span className="font-medium">Eval cloud</span>
+      <span className="text-[0.7rem] text-muted-foreground">{label}</span>
+    </Badge>
+  );
+}
+
+export default LiveEvalBadge;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -5,3 +5,6 @@ verify_jwt = false
 
 [functions.generate-custom-rules]
 verify_jwt = false
+
+[functions.live-eval]
+verify_jwt = false

--- a/supabase/functions/live-eval/index.ts
+++ b/supabase/functions/live-eval/index.ts
@@ -1,0 +1,434 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { TextLineStream } from 'https://deno.land/std@0.224.0/streams/text_line_stream.ts';
+
+interface EngineEvaluation {
+  type: 'cp' | 'mate';
+  value: number;
+}
+
+interface EvalResult {
+  bestMove: string;
+  evaluation: EngineEvaluation;
+}
+
+interface WorkerConfig {
+  depth: number;
+  threads: number;
+  hash: number;
+  moveTimeMs: number;
+}
+
+interface EvalRequest {
+  fen: string;
+  ply: number;
+}
+
+interface EvalMessage {
+  type: 'fen';
+  fen: string;
+  ply?: number;
+}
+
+interface ReadyMessage {
+  type: 'ready';
+  depth: number;
+  threads: number;
+}
+
+interface EvalResponse {
+  type: 'eval';
+  ply: number;
+  bestMove: string;
+  evaluation: EngineEvaluation;
+  depth: number;
+  engineTimeMs: number;
+  fen: string;
+}
+
+interface ErrorResponse {
+  type: 'error';
+  message: string;
+}
+
+class StockfishWorker {
+  private process: Deno.ChildProcess;
+
+  private stdoutQueue: string[] = [];
+
+  private waiters: Array<(line: string) => void> = [];
+
+  private terminated = false;
+
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+
+  private readonly encoder = new TextEncoder();
+
+  constructor(private readonly config: WorkerConfig) {
+    const binary = Deno.env.get('STOCKFISH_PATH') ?? './stockfish';
+    const command = new Deno.Command(binary, {
+      stdin: 'piped',
+      stdout: 'piped',
+      stderr: 'null',
+    });
+
+    this.process = command.spawn();
+    this.writer = this.process.stdin.getWriter();
+    const reader = this.process.stdout
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TextLineStream());
+    void this.consume(reader);
+  }
+
+  get depth(): number {
+    return this.config.depth;
+  }
+
+  get threads(): number {
+    return this.config.threads;
+  }
+
+  private async consume(stream: ReadableStream<string>) {
+    try {
+      for await (const line of stream) {
+        if (this.waiters.length > 0) {
+          const waiter = this.waiters.shift();
+          waiter?.(line);
+        } else {
+          this.stdoutQueue.push(line);
+        }
+      }
+    } finally {
+      this.terminated = true;
+    }
+  }
+
+  private async readLine(): Promise<string> {
+    if (this.stdoutQueue.length > 0) {
+      return this.stdoutQueue.shift() as string;
+    }
+    if (this.terminated) {
+      throw new Error('Stockfish process terminated unexpectedly');
+    }
+    return new Promise<string>((resolve) => this.waiters.push(resolve));
+  }
+
+  private async write(command: string) {
+    await this.writer.write(this.encoder.encode(`${command}\n`));
+  }
+
+  private async setOption(name: string, value: string | number | boolean) {
+    const formatted = typeof value === 'boolean' ? (value ? 'true' : 'false') : `${value}`;
+    await this.write(`setoption name ${name} value ${formatted}`);
+  }
+
+  async initialize() {
+    await this.write('uci');
+    let line = '';
+    do {
+      line = await this.readLine();
+    } while (!line.includes('uciok'));
+
+    await this.setOption('MultiPV', 1);
+    await this.setOption('Threads', Math.max(1, this.config.threads));
+    await this.setOption('Hash', Math.max(16, this.config.hash));
+
+    await this.write('isready');
+    do {
+      line = await this.readLine();
+    } while (!line.includes('readyok'));
+  }
+
+  async evaluate(fen: string): Promise<EvalResult> {
+    await this.write('ucinewgame');
+    await this.write(`position fen ${fen}`);
+
+    const goCommand = `go depth ${this.config.depth}`;
+    await this.write(goCommand);
+
+    let stopTimer: number | undefined;
+    if (this.config.moveTimeMs > 0) {
+      stopTimer = setTimeout(() => {
+        void this.write('stop');
+      }, this.config.moveTimeMs);
+    }
+
+    try {
+      let bestMove = '';
+      let evaluation: EngineEvaluation | null = null;
+
+      while (true) {
+        const payload = await this.readLine();
+        if (payload.startsWith('info') && payload.includes('score')) {
+          const parsed = extractEvaluation(payload);
+          if (parsed) {
+            evaluation = parsed;
+          }
+        }
+
+        if (payload.startsWith('bestmove')) {
+          const match = payload.match(/bestmove (\S+)/);
+          if (match) {
+            bestMove = match[1];
+          }
+          break;
+        }
+      }
+
+      return {
+        bestMove,
+        evaluation: evaluation ?? { type: 'cp', value: 0 },
+      };
+    } finally {
+      if (typeof stopTimer === 'number') {
+        clearTimeout(stopTimer);
+      }
+    }
+  }
+
+  async dispose() {
+    try {
+      await this.write('quit');
+    } catch (_) {
+      // ignore
+    }
+    try {
+      await this.writer.close();
+    } catch (_) {
+      // ignore
+    }
+    try {
+      await this.process.status;
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  isTerminated(): boolean {
+    return this.terminated;
+  }
+}
+
+class StockfishPool {
+  private available: StockfishWorker[] = [];
+
+  private waiters: Array<(worker: StockfishWorker) => void> = [];
+
+  private constructor(private readonly config: WorkerConfig, private readonly size: number) {}
+
+  static async create(config: WorkerConfig, size: number): Promise<StockfishPool> {
+    const pool = new StockfishPool(config, size);
+    await pool.populate();
+    return pool;
+  }
+
+  private async populate() {
+    const workers = await Promise.all(
+      Array.from({ length: this.size }, async () => {
+        const worker = new StockfishWorker(this.config);
+        await worker.initialize();
+        return worker;
+      }),
+    );
+    this.available.push(...workers);
+  }
+
+  async acquire(): Promise<StockfishWorker> {
+    if (this.available.length > 0) {
+      return this.available.shift() as StockfishWorker;
+    }
+    return new Promise<StockfishWorker>((resolve) => this.waiters.push(resolve));
+  }
+
+  release(worker: StockfishWorker) {
+    if (worker.isTerminated()) {
+      void this.spawnReplacement();
+      return;
+    }
+
+    if (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      waiter?.(worker);
+    } else {
+      this.available.push(worker);
+    }
+  }
+
+  private async spawnReplacement() {
+    try {
+      const worker = new StockfishWorker(this.config);
+      await worker.initialize();
+      if (this.waiters.length > 0) {
+        const waiter = this.waiters.shift();
+        waiter?.(worker);
+      } else {
+        this.available.push(worker);
+      }
+    } catch (error) {
+      console.error('Failed to spawn replacement Stockfish worker', error);
+    }
+  }
+}
+
+function extractEvaluation(payload: string): EngineEvaluation | null {
+  const mateMatch = payload.match(/score mate (-?\d+)/);
+  if (mateMatch) {
+    return { type: 'mate', value: Number.parseInt(mateMatch[1], 10) };
+  }
+  const cpMatch = payload.match(/score cp (-?\d+)/);
+  if (cpMatch) {
+    return { type: 'cp', value: Number.parseInt(cpMatch[1], 10) };
+  }
+  return null;
+}
+
+function parseMessage(data: unknown): EvalMessage | null {
+  if (typeof data !== 'string') return null;
+  try {
+    const parsed = JSON.parse(data) as EvalMessage;
+    if (parsed && parsed.type === 'fen' && typeof parsed.fen === 'string') {
+      const ply = typeof parsed.ply === 'number' && Number.isFinite(parsed.ply) ? parsed.ply : 0;
+      return { type: 'fen', fen: parsed.fen, ply };
+    }
+  } catch (_) {
+    return null;
+  }
+  return null;
+}
+
+const poolPromise = StockfishPool.create(
+  {
+    depth: Number.parseInt(Deno.env.get('LIVE_EVAL_DEPTH') ?? '18', 10),
+    threads: Number.parseInt(Deno.env.get('LIVE_EVAL_THREADS') ?? '2', 10),
+    hash: Number.parseInt(Deno.env.get('LIVE_EVAL_HASH') ?? '64', 10),
+    moveTimeMs: Number.parseInt(Deno.env.get('LIVE_EVAL_TIME_MS') ?? '450', 10),
+  },
+  Number.parseInt(Deno.env.get('LIVE_EVAL_POOL_SIZE') ?? '3', 10),
+);
+
+serve(async (req) => {
+  if (req.headers.get('upgrade') !== 'websocket') {
+    return new Response('Expected WebSocket upgrade', { status: 400 });
+  }
+
+  const pool = await poolPromise;
+  const { socket, response } = Deno.upgradeWebSocket(req);
+
+  handleSocket(socket, pool);
+
+  return response;
+});
+
+function handleSocket(socket: WebSocket, pool: StockfishPool) {
+  let worker: StockfishWorker | null = null;
+  let closed = false;
+  let processing = false;
+  let queued: EvalRequest | null = null;
+
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    if (worker) {
+      pool.release(worker);
+      worker = null;
+    }
+  };
+
+  const flushQueue = async () => {
+    if (processing || !worker || !queued) {
+      return;
+    }
+    const request = queued;
+    queued = null;
+    processing = true;
+    const startedAt = performance.now();
+
+    try {
+      const result = await worker.evaluate(request.fen);
+      const elapsed = performance.now() - startedAt;
+      const payload: EvalResponse = {
+        type: 'eval',
+        ply: request.ply,
+        bestMove: result.bestMove,
+        evaluation: result.evaluation,
+        depth: worker.depth,
+        engineTimeMs: Math.round(elapsed),
+        fen: request.fen,
+      };
+      socket.send(JSON.stringify(payload));
+    } catch (error) {
+      console.error('live-eval worker error', error);
+      const message: ErrorResponse = {
+        type: 'error',
+        message: 'Engine failure',
+      };
+      try {
+        socket.send(JSON.stringify(message));
+      } catch (_) {
+        // ignore send errors
+      }
+      cleanup();
+      socket.close(1011, 'Engine failure');
+      return;
+    } finally {
+      processing = false;
+    }
+
+    if (queued && !closed) {
+      void flushQueue();
+    }
+  };
+
+  socket.onopen = () => {
+    void (async () => {
+      try {
+        worker = await pool.acquire();
+        if (closed) {
+          if (worker) {
+            pool.release(worker);
+            worker = null;
+          }
+          return;
+        }
+        const ready: ReadyMessage = {
+          type: 'ready',
+          depth: worker.depth,
+          threads: worker.threads,
+        };
+        socket.send(JSON.stringify(ready));
+        if (queued) {
+          void flushQueue();
+        }
+      } catch (error) {
+        console.error('Failed to acquire Stockfish worker', error);
+        const message: ErrorResponse = {
+          type: 'error',
+          message: 'Engine unavailable',
+        };
+        try {
+          socket.send(JSON.stringify(message));
+        } catch (_) {
+          // ignore
+        }
+        socket.close(1013, 'Engine unavailable');
+      }
+    })();
+  };
+
+  socket.onmessage = (event) => {
+    if (closed) return;
+    const message = parseMessage(event.data);
+    if (!message) return;
+    queued = { fen: message.fen, ply: message.ply ?? 0 };
+    if (!processing && worker) {
+      void flushQueue();
+    }
+  };
+
+  socket.onerror = () => {
+    cleanup();
+  };
+
+  socket.onclose = () => {
+    cleanup();
+  };
+}


### PR DESCRIPTION
## Summary
- add a Supabase Edge Function that serves a pooled Stockfish websocket feed for live evaluations
- expose a LiveEvalBadge component that consumes the websocket stream with reconnection and latency tracking
- surface a toggleable "Eval cloud" badge in the chess game header and wire Supabase config for the new function

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcc2c51cc48323b490865fc3404bd3