### PR TITLE
Improve coach speech voice naturalness

### DIFF
--- a/src/components/CoachingPanel.tsx
+++ b/src/components/CoachingPanel.tsx
@@ -23,6 +23,7 @@ export function CoachingPanel({ comment, analysis, isAnalyzing, language, isEnab
     rate: config.speech.rate,
     pitch: config.speech.pitch,
     volume: config.speech.volume,
+    language: config.speech.language,
   });
 
   const getCommentType = () => {

--- a/src/hooks/use-speech.ts
+++ b/src/hooks/use-speech.ts
@@ -5,12 +5,13 @@ interface SpeechOptions {
   rate?: number;
   pitch?: number;
   volume?: number;
+  language?: string;
 }
 
 const DEFAULT_PREFERENCES = ["Google", "Amelie", "Thomas", "fr", "French"];
 
 export function useSpeechSynthesis(text: string, options: SpeechOptions = {}) {
-  const lastUtteranceRef = useRef<string>("");
+  const lastUtteranceRef = useRef<{ text: string; language?: string }>({ text: "", language: undefined });
 
   useEffect(() => {
     if (!text || !text.trim() || typeof window === "undefined") return;
@@ -18,12 +19,13 @@ export function useSpeechSynthesis(text: string, options: SpeechOptions = {}) {
     const synthesis = window.speechSynthesis;
     if (!synthesis) return;
 
-    if (text === lastUtteranceRef.current) return;
+    if (text === lastUtteranceRef.current.text && options.language === lastUtteranceRef.current.language) return;
 
     const voicePreferences = options.voicePreferences?.length ? options.voicePreferences : DEFAULT_PREFERENCES;
     const rate = options.rate ?? 0.98;
     const pitch = options.pitch ?? 1;
     const volume = options.volume ?? 1;
+    const language = options.language?.toLowerCase();
 
     let cancelled = false;
 
@@ -31,20 +33,31 @@ export function useSpeechSynthesis(text: string, options: SpeechOptions = {}) {
       if (cancelled || !voices.length) return;
 
       const normalizedPreferences = voicePreferences.map((pref) => pref.toLowerCase());
+      const isLanguageMatch = (voice: SpeechSynthesisVoice) =>
+        language ? voice.lang?.toLowerCase().startsWith(language) : true;
+      const languageMatches = voices.filter((voice) => isLanguageMatch(voice));
+      const findByPreference = (candidateVoices: SpeechSynthesisVoice[]) =>
+        candidateVoices.find((voice) =>
+          normalizedPreferences.some((pref) => voice.name.toLowerCase().includes(pref) || voice.voiceURI.toLowerCase().includes(pref)),
+        );
+
       const preferredVoice =
-        voices.find((voice) => normalizedPreferences.some((pref) => voice.name.toLowerCase().includes(pref))) ||
-        voices.find((voice) => voice.lang.toLowerCase().startsWith("fr")) ||
+        findByPreference(languageMatches) ||
+        languageMatches.find((voice) => !voice.localService) ||
+        languageMatches[0] ||
+        findByPreference(voices) ||
+        voices.find((voice) => voice.lang?.toLowerCase().startsWith(language ?? "")) ||
         voices[0];
 
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.voice = preferredVoice;
-      utterance.lang = preferredVoice?.lang ?? "fr-FR";
+      utterance.lang = options.language ?? preferredVoice?.lang ?? "fr-FR";
       utterance.rate = rate;
       utterance.pitch = pitch;
       utterance.volume = volume;
 
       synthesis.cancel();
-      lastUtteranceRef.current = text;
+      lastUtteranceRef.current = { text, language: options.language };
       synthesis.speak(utterance);
     };
 
@@ -67,7 +80,7 @@ export function useSpeechSynthesis(text: string, options: SpeechOptions = {}) {
       synthesis.removeEventListener("voiceschanged", handleVoicesChanged);
       synthesis.cancel();
     };
-  }, [text, options.voicePreferences, options.rate, options.pitch, options.volume]);
+  }, [text, options.voicePreferences, options.rate, options.pitch, options.volume, options.language]);
 }
 
 export default useSpeechSynthesis;

--- a/src/lib/coachLanguage.ts
+++ b/src/lib/coachLanguage.ts
@@ -40,6 +40,7 @@ interface CoachLanguageConfig {
     rate: number;
     pitch: number;
     volume: number;
+    language: string;
   };
   opponentPrefix: string;
   enginePrefix: string;
@@ -84,6 +85,7 @@ const LANGUAGE_CONFIG: Record<CoachLanguage, CoachLanguageConfig> = {
       rate: 0.94,
       pitch: 1.04,
       volume: 0.9,
+      language: "fr-FR",
     },
     opponentPrefix: "Adversaire",
     enginePrefix: "IA",
@@ -126,6 +128,7 @@ const LANGUAGE_CONFIG: Record<CoachLanguage, CoachLanguageConfig> = {
       rate: 1,
       pitch: 1,
       volume: 0.9,
+      language: "en-US",
     },
     opponentPrefix: "Opponent",
     enginePrefix: "AI",
@@ -168,6 +171,7 @@ const LANGUAGE_CONFIG: Record<CoachLanguage, CoachLanguageConfig> = {
       rate: 0.98,
       pitch: 1,
       volume: 0.9,
+      language: "es-ES",
     },
     opponentPrefix: "Oponente",
     enginePrefix: "IA",


### PR DESCRIPTION
## Summary
- ensure the speech synthesis hook keeps track of the utterance language and prefers voices that match the requested locale for more natural pronunciation
- add explicit locale metadata to each coach language configuration and forward it to the speech system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcde3fc6f08323b84ffdec28e6cafb