### PR TITLE
Call onTurnStart when creating matches

### DIFF
--- a/src/variant-chess-lobby.ts
+++ b/src/variant-chess-lobby.ts
@@ -1338,6 +1338,7 @@ export function createMatch(
   const rule = getRuleById(ruleId);
   if (!rule) throw new Error(`Règle inconnue: ${ruleId}`);
   const composite = new RuleComposite([rule]); // 1 règle par salle
+  composite.onTurnStart(initialState, engine);
   return {
     id: `match-${Date.now()}`,
     vsAI,


### PR DESCRIPTION
## Summary
- invoke the composite start-of-turn hook during match creation so the opening state benefits from rule setup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dced30094c83239cf8e82168aa0302