### PR TITLE
Sanitize generated plugin code before registering

### DIFF
--- a/supabase/functions/generate-custom-rules/index.ts
+++ b/supabase/functions/generate-custom-rules/index.ts
@@ -279,8 +279,22 @@ RÈGLES DÉTAILLÉES:\n${customRules}`;
             .join('\n')
             .trim();
 
-          if (generatedCode && generatedCode.includes(ruleId)) {
-            pluginCode = generatedCode;
+          if (generatedCode) {
+            const sanitizedCode = generatedCode
+              .replace(/^```[a-zA-Z]*\n?/, '')
+              .replace(/\n?```$/, '')
+              .trim();
+
+            const referencesRuleId =
+              sanitizedCode.includes(ruleId) || sanitizedCode.includes('helpers.ruleId');
+            const exportsModule = /module\.exports\s*=/.test(sanitizedCode);
+
+            if (referencesRuleId && exportsModule) {
+              pluginCode = sanitizedCode;
+            } else {
+              pluginWarning =
+                'Le code généré ne contient pas les références attendues. Utilisation d’un squelette de règle.';
+            }
           } else {
             pluginWarning = 'La génération du code automatique a échoué. Utilisation d’un squelette de règle.';
           }


### PR DESCRIPTION
## Summary
- strip Markdown fences from AI generated plugin code before registration
- verify the generated code references the rule identifier or helpers and exports a module
- fall back to the demo skeleton when the generated code is incomplete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12a46fe48832382a560063153385a