### PR TITLE
feat: compile custom chess rules into declarative JSON rulesets

### DIFF
--- a/src/features/play/routes/Lobby.tsx
+++ b/src/features/play/routes/Lobby.tsx
@@ -19,6 +19,7 @@ import {
   getRuleById,
   registerExternalRuleFromSource,
 } from "@/variant-chess-lobby";
+import type { RuleSpec } from "@/lib/rulesets/types";
 import { toast } from "sonner";
 import { Clock, Users, Sword, Hourglass, PlusCircle, XCircle, AlertTriangle } from "lucide-react";
 
@@ -98,6 +99,13 @@ type VariantMetadata = {
     createdAt?: string | null;
     warning?: string | null;
   };
+  compiled?: {
+    hash?: string | null;
+    generatedAt?: string | null;
+    warnings?: string[];
+    ruleset?: unknown;
+  };
+  ruleSpec?: RuleSpec | null;
 };
 
 const parseVariantMetadata = (metadata: unknown): VariantMetadata => {
@@ -120,6 +128,22 @@ const parseVariantMetadata = (metadata: unknown): VariantMetadata => {
       createdAt: typeof plugin.createdAt === "string" ? plugin.createdAt : undefined,
       warning: typeof plugin.warning === "string" ? plugin.warning : undefined,
     };
+  }
+
+  if (base.compiled && typeof base.compiled === "object") {
+    const compiled = base.compiled as Record<string, unknown>;
+    parsed.compiled = {
+      hash: typeof compiled.hash === "string" ? compiled.hash : undefined,
+      generatedAt: typeof compiled.generatedAt === "string" ? compiled.generatedAt : undefined,
+      warnings: Array.isArray(compiled.warnings)
+        ? (compiled.warnings as string[])
+        : undefined,
+      ruleset: compiled.ruleset,
+    };
+  }
+
+  if (base.ruleSpec && typeof base.ruleSpec === "object") {
+    parsed.ruleSpec = base.ruleSpec as RuleSpec;
   }
 
   return parsed;

--- a/src/lib/rulesets/types.ts
+++ b/src/lib/rulesets/types.ts
@@ -1,0 +1,80 @@
+export type MovePattern =
+  | { pattern: "rook" | "bishop" | "queen" | "knight" | "king" | "pawn"; repeat?: number }
+  | { action: "carry"; who: "pawn" | "any"; range: number; constraints?: string[] }
+  | { action: "dash"; max: number; requires?: string[] };
+
+export interface PieceSpec {
+  id: string;
+  from?: "rook" | "bishop" | "queen" | "knight" | "king" | "pawn";
+  side?: "white" | "black" | "both";
+  moves: MovePattern[];
+  spawn?: { promotesFrom?: string | null; count?: number; startSquares?: string[] };
+}
+
+export interface EffectSpec {
+  id: string;
+  trigger: "onMove" | "onCapture" | "onHit" | "onTurnStart" | "onTurnEnd";
+  target: "self" | "allyPiece" | "enemyPiece" | "square" | "any";
+  durationTurns?: number;
+  mod: Record<string, unknown>;
+  conditions?: string[];
+  priority?: number;
+}
+
+export interface RulesCore {
+  turnOrder: "whiteThenBlack" | "simultaneous";
+  checkRules: "classic" | "disabled" | "altX";
+  promotion: Array<{ piece: string; to: string[] }>;
+  winConditions: Array<{ type: "checkmate" | "timeout" | "stalemate" | "captureAll" | "custom"; params?: unknown }>;
+  conflictPolicy: {
+    onDuplicatePieceId: "error" | "rename";
+    onMoveOverride: "replace" | "extend";
+    onEffectCollision: "priorityHighWins" | "stack" | "error";
+  };
+}
+
+export interface RuleTestStep {
+  move?: string;
+  by?: string;
+  assert?: string;
+  square?: string;
+  piece?: string;
+  side?: string;
+  value?: unknown;
+}
+
+export interface RuleTest {
+  name: string;
+  fen: string;
+  script: RuleTestStep[];
+}
+
+export interface CompiledRuleset {
+  meta: { name: string; base: string; version: string; description?: string; priority?: number };
+  board: { size: "8x8" | "10x10"; zones: unknown[] };
+  pieces: PieceSpec[];
+  effects: EffectSpec[];
+  rules: RulesCore;
+  tests?: RuleTest[];
+}
+
+export type PatchOperation = "extend" | "replace" | "remove";
+
+export interface RulePatch {
+  op: PatchOperation;
+  path: string;
+  value?: unknown;
+  priority?: number;
+}
+
+export interface RuleSpec {
+  meta: {
+    name: string;
+    base: string;
+    version: string;
+    description?: string;
+    priority?: number;
+  };
+  patches?: RulePatch[];
+  tests?: RuleTest[];
+}

--- a/supabase/functions/_shared/rulesets/base/chess-base@1.0.0.json
+++ b/supabase/functions/_shared/rulesets/base/chess-base@1.0.0.json
@@ -1,0 +1,105 @@
+{
+  "meta": {
+    "name": "Standard Chess",
+    "base": "chess-base@1.0.0",
+    "version": "1.0.0",
+    "description": "Règles FIDE classiques d'échecs sur échiquier 8x8.",
+    "priority": 0
+  },
+  "board": {
+    "size": "8x8",
+    "zones": []
+  },
+  "pieces": [
+    {
+      "id": "king",
+      "from": "king",
+      "side": "both",
+      "moves": [{ "pattern": "king" }],
+      "spawn": { "count": 1, "startSquares": ["e1", "e8"] }
+    },
+    {
+      "id": "queen",
+      "from": "queen",
+      "side": "both",
+      "moves": [{ "pattern": "queen" }],
+      "spawn": { "count": 1, "startSquares": ["d1", "d8"] }
+    },
+    {
+      "id": "rook",
+      "from": "rook",
+      "side": "both",
+      "moves": [{ "pattern": "rook" }],
+      "spawn": { "count": 2, "startSquares": ["a1", "h1", "a8", "h8"] }
+    },
+    {
+      "id": "bishop",
+      "from": "bishop",
+      "side": "both",
+      "moves": [{ "pattern": "bishop" }],
+      "spawn": { "count": 2, "startSquares": ["c1", "f1", "c8", "f8"] }
+    },
+    {
+      "id": "knight",
+      "from": "knight",
+      "side": "both",
+      "moves": [{ "pattern": "knight" }],
+      "spawn": { "count": 2, "startSquares": ["b1", "g1", "b8", "g8"] }
+    },
+    {
+      "id": "pawn",
+      "from": "pawn",
+      "side": "both",
+      "moves": [{ "pattern": "pawn" }],
+      "spawn": {
+        "count": 8,
+        "startSquares": [
+          "a2",
+          "b2",
+          "c2",
+          "d2",
+          "e2",
+          "f2",
+          "g2",
+          "h2",
+          "a7",
+          "b7",
+          "c7",
+          "d7",
+          "e7",
+          "f7",
+          "g7",
+          "h7"
+        ]
+      }
+    }
+  ],
+  "effects": [],
+  "rules": {
+    "turnOrder": "whiteThenBlack",
+    "checkRules": "classic",
+    "promotion": [
+      { "piece": "pawn", "to": ["queen", "rook", "bishop", "knight"] }
+    ],
+    "winConditions": [
+      { "type": "checkmate" },
+      { "type": "timeout" },
+      { "type": "stalemate", "params": { "result": "draw" } }
+    ],
+    "conflictPolicy": {
+      "onDuplicatePieceId": "error",
+      "onMoveOverride": "replace",
+      "onEffectCollision": "priorityHighWins"
+    }
+  },
+  "tests": [
+    {
+      "name": "Pawn opening",
+      "fen": "startpos",
+      "script": [
+        { "move": "e2-e4", "by": "pawn" },
+        { "assert": "turn", "value": "black" }
+      ]
+    }
+  ]
+}

--- a/supabase/functions/_shared/rulesets/base/index.ts
+++ b/supabase/functions/_shared/rulesets/base/index.ts
@@ -1,0 +1,26 @@
+import chessBase100 from "./chess-base@1.0.0.json" assert { type: "json" };
+import type { CompiledRuleset } from "../types.ts";
+
+const registry: Record<string, CompiledRuleset> = {
+  "chess-base@1.0.0": chessBase100 as CompiledRuleset,
+  "chess-base@1.2.0": chessBase100 as CompiledRuleset,
+};
+
+export function resolveBaseRuleset(baseId: string): CompiledRuleset {
+  const key = baseId.trim();
+  const base = registry[key];
+  if (!base) {
+    throw new Error(`Base ruleset not found: ${key}`);
+  }
+
+  // structuredClone not available in some bundlers, fallback to JSON.
+  if (typeof structuredClone === "function") {
+    return structuredClone(base);
+  }
+
+  return JSON.parse(JSON.stringify(base)) as CompiledRuleset;
+}
+
+export function listAvailableBases(): string[] {
+  return Object.keys(registry);
+}

--- a/supabase/functions/_shared/rulesets/compiler.ts
+++ b/supabase/functions/_shared/rulesets/compiler.ts
@@ -1,0 +1,218 @@
+import { resolveBaseRuleset } from "./base/index.ts";
+import type {
+  CompiledRuleset,
+  CompilationResult,
+  RulePatch,
+  RuleSpec,
+} from "./types.ts";
+
+export class RuleCompilationError extends Error {
+  constructor(message: string, readonly path?: string) {
+    super(message);
+    this.name = "RuleCompilationError";
+  }
+}
+
+const DEFAULT_PRIORITY = 50;
+
+function deepClone<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function parseSegment(segment: string) {
+  const match = segment.match(/^([^[]+)(?:\[id=([^]]+)\])?$/);
+  if (!match) {
+    throw new RuleCompilationError(`Invalid patch path segment: ${segment}`);
+  }
+  return { key: match[1], selector: match[2] };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getArrayItem(
+  container: unknown,
+  selector: string,
+  path: string,
+): { array: unknown[]; index: number } {
+  if (!Array.isArray(container)) {
+    throw new RuleCompilationError(`Path does not target an array: ${path}`);
+  }
+  const index = container.findIndex((item) => isObject(item) && (item as { id?: string }).id === selector);
+  if (index === -1) {
+    throw new RuleCompilationError(`Unable to find id=${selector} in path ${path}`);
+  }
+  return { array: container, index };
+}
+
+function resolveParent(target: CompiledRuleset, path: string) {
+  const segments = path.split(".").filter(Boolean);
+  if (segments.length === 0) {
+    throw new RuleCompilationError("Patch path cannot be empty");
+  }
+
+  let current: unknown = target;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    if (!isObject(current)) {
+      throw new RuleCompilationError(`Cannot traverse path ${path}`);
+    }
+    const { key, selector } = parseSegment(segments[i]);
+    if (!(key in current)) {
+      (current as Record<string, unknown>)[key] = selector ? [] : {};
+    }
+    const next = (current as Record<string, unknown>)[key];
+    if (selector) {
+      const { array, index } = getArrayItem(next, selector, path);
+      current = array[index];
+    } else {
+      current = next;
+    }
+  }
+
+  const { key, selector } = parseSegment(segments[segments.length - 1]);
+  if (!isObject(current)) {
+    throw new RuleCompilationError(`Cannot access property ${key} on non-object in path ${path}`);
+  }
+
+  return { parent: current as Record<string, unknown>, key, selector };
+}
+
+function applyPatch(target: CompiledRuleset, patch: RulePatch) {
+  const { parent, key, selector } = resolveParent(target, patch.path);
+
+  switch (patch.op) {
+    case "replace": {
+      if (selector) {
+        const container = parent[key];
+        const { array, index } = getArrayItem(container, selector, patch.path);
+        array[index] = patch.value;
+      } else {
+        parent[key] = patch.value as unknown;
+      }
+      break;
+    }
+    case "extend": {
+      if (selector) {
+        throw new RuleCompilationError(
+          `Extend operation cannot target a specific array element (${patch.path})`,
+          patch.path,
+        );
+      }
+
+      if (patch.value === undefined) {
+        throw new RuleCompilationError(`Extend operation requires a value at ${patch.path}`);
+      }
+
+      let container = parent[key];
+      if (container === undefined) {
+        parent[key] = [];
+        container = parent[key];
+      }
+
+      if (!Array.isArray(container)) {
+        throw new RuleCompilationError(`Target at ${patch.path} is not an array`);
+      }
+
+      if (Array.isArray(patch.value)) {
+        container.push(...patch.value);
+      } else {
+        container.push(patch.value);
+      }
+      break;
+    }
+    case "remove": {
+      if (selector) {
+        const container = parent[key];
+        const { array, index } = getArrayItem(container, selector, patch.path);
+        array.splice(index, 1);
+      } else {
+        delete parent[key];
+      }
+      break;
+    }
+    default:
+      throw new RuleCompilationError(`Unsupported patch operation: ${patch.op}`);
+  }
+}
+
+function applyPatches(target: CompiledRuleset, patches: RulePatch[] = []) {
+  const sorted = [...patches].sort(
+    (a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY),
+  );
+
+  for (const patch of sorted) {
+    applyPatch(target, patch);
+  }
+}
+
+function validateCompiledRuleset(ruleset: CompiledRuleset): string[] {
+  const warnings: string[] = [];
+
+  const pieceIds = new Set<string>();
+  for (const piece of ruleset.pieces) {
+    if (pieceIds.has(piece.id)) {
+      throw new RuleCompilationError(`Duplicate piece id detected: ${piece.id}`);
+    }
+    pieceIds.add(piece.id);
+  }
+
+  if (ruleset.rules.checkRules === "classic") {
+    const hasKing = ruleset.pieces.some((piece) => piece.id === "king" || piece.from === "king");
+    if (!hasKing) {
+      throw new RuleCompilationError(
+        "Classic check rules require at least one king definition",
+      );
+    }
+  }
+
+  return warnings;
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortObjectKeys(item));
+  }
+
+  if (isObject(value)) {
+    const sortedEntries = Object.keys(value)
+      .sort()
+      .map((key) => [key, sortObjectKeys((value as Record<string, unknown>)[key])]);
+    return Object.fromEntries(sortedEntries);
+  }
+
+  return value;
+}
+
+async function computeRulesetHash(ruleset: CompiledRuleset): Promise<string> {
+  const canonical = JSON.stringify(sortObjectKeys(ruleset));
+  const data = new TextEncoder().encode(canonical);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function compileRuleSpec(spec: RuleSpec): Promise<CompilationResult> {
+  const baseId = spec.meta.base || "chess-base@1.0.0";
+  const base = resolveBaseRuleset(baseId);
+  const compiled = deepClone(base);
+
+  compiled.meta = { ...compiled.meta, ...spec.meta, base: baseId };
+
+  if (spec.patches && spec.patches.length > 0) {
+    applyPatches(compiled, spec.patches);
+  }
+
+  if (spec.tests) {
+    compiled.tests = spec.tests;
+  }
+
+  const warnings = validateCompiledRuleset(compiled);
+  const hash = await computeRulesetHash(compiled);
+
+  return { compiled, hash, warnings };
+}

--- a/supabase/functions/_shared/rulesets/types.ts
+++ b/supabase/functions/_shared/rulesets/types.ts
@@ -1,0 +1,86 @@
+export type MovePattern =
+  | { pattern: "rook" | "bishop" | "queen" | "knight" | "king" | "pawn"; repeat?: number }
+  | { action: "carry"; who: "pawn" | "any"; range: number; constraints?: string[] }
+  | { action: "dash"; max: number; requires?: string[] };
+
+export interface PieceSpec {
+  id: string;
+  from?: "rook" | "bishop" | "queen" | "knight" | "king" | "pawn";
+  side?: "white" | "black" | "both";
+  moves: MovePattern[];
+  spawn?: { promotesFrom?: string | null; count?: number; startSquares?: string[] };
+}
+
+export interface EffectSpec {
+  id: string;
+  trigger: "onMove" | "onCapture" | "onHit" | "onTurnStart" | "onTurnEnd";
+  target: "self" | "allyPiece" | "enemyPiece" | "square" | "any";
+  durationTurns?: number;
+  mod: Record<string, unknown>;
+  conditions?: string[];
+  priority?: number;
+}
+
+export interface RulesCore {
+  turnOrder: "whiteThenBlack" | "simultaneous";
+  checkRules: "classic" | "disabled" | "altX";
+  promotion: Array<{ piece: string; to: string[] }>;
+  winConditions: Array<{ type: "checkmate" | "timeout" | "stalemate" | "captureAll" | "custom"; params?: unknown }>;
+  conflictPolicy: {
+    onDuplicatePieceId: "error" | "rename";
+    onMoveOverride: "replace" | "extend";
+    onEffectCollision: "priorityHighWins" | "stack" | "error";
+  };
+}
+
+export interface RuleTestStep {
+  move?: string;
+  by?: string;
+  assert?: string;
+  square?: string;
+  piece?: string;
+  side?: string;
+  value?: unknown;
+}
+
+export interface RuleTest {
+  name: string;
+  fen: string;
+  script: RuleTestStep[];
+}
+
+export interface CompiledRuleset {
+  meta: { name: string; base: string; version: string; description?: string; priority?: number };
+  board: { size: "8x8" | "10x10"; zones: unknown[] };
+  pieces: PieceSpec[];
+  effects: EffectSpec[];
+  rules: RulesCore;
+  tests?: RuleTest[];
+}
+
+export type PatchOperation = "extend" | "replace" | "remove";
+
+export interface RulePatch {
+  op: PatchOperation;
+  path: string;
+  value?: unknown;
+  priority?: number;
+}
+
+export interface RuleSpec {
+  meta: {
+    name: string;
+    base: string;
+    version: string;
+    description?: string;
+    priority?: number;
+  };
+  patches?: RulePatch[];
+  tests?: RuleTest[];
+}
+
+export interface CompilationResult {
+  compiled: CompiledRuleset;
+  hash: string;
+  warnings: string[];
+}


### PR DESCRIPTION
## Summary
- add shared ruleset schema files, a standard chess base ruleset, and a compiler utility for combining patches into compiled variants
- rewrite the `generate-custom-rules` Supabase function to request JSON rule specs, compile them server-side, and return hashed `CompiledRuleset` payloads
- update the custom rules generator UI to surface compiled ruleset metadata, store specs in variant metadata, and extend lobby parsing to understand the new fields

## Testing
- npm run lint *(fails: repository already contains `no-explicit-any` violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e13a528a3c8323aed4bc95c6fddc59