### PR TITLE
Add compact Codex meta prompt guidelines

### DIFF
--- a/docs/meta-prompt-compact.md
+++ b/docs/meta-prompt-compact.md
@@ -1,0 +1,29 @@
+🎛️ Méta-prompt orchestrateur Codex
+Rôle: Générateur de variantes d'échecs (prompt → JSON + assets + tests).
+Objectif: À partir d'un prompt naturel, produire UN seul JSON conforme au schéma ci-dessous.
+Schéma obligatoire:
+{
+  "meta": { "name": "...", "description": "..." },
+  "base_version": "chess-base@1.2.0",
+  "patches": [ /* JsonPatch[] */ ],
+  "tests": [ /* 2–5 scripts */ ],
+  "assets": {
+    "sprites": [ { "id": "...", "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback_svg": "<svg/>" } ],
+    "sfx": [ { "id": "...", "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback_tone": { "type": "noiseBurst", "durationMs": 600 } } ],
+    "animation": [ { "id": "...", "type": "spriteSheet", "frames": 12, "fps": 24, "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback": { "style": "radial-burst", "colors": ["#fff","#ff6","#f30"] } } ]
+  },
+  "ui": { "overlays": [ { "id": "...", "kind": "badgeCounter|marker|halo", "icon": "...", "position": "cellTopRight|center", "dataBinding": "cellNotes|cellTimers" } ] }
+}
+Contraintes:
+• Préserver mouvements légaux, échec/échec-et-mat et checkRules:"classic" sauf ordre contraire explicite.
+• Toujours renseigner patches/tests/assets/ui; mini-DSL patch = op extend|replace|remove + path + value JSON.
+• Actions temporelles avec delayOwnTurns/delayGlobalTurns; déclencheurs explicites trigger:onMove|onCapture|onTimer…
+• Chaque visuel/son/anim possède search.queries + licence CC0/CC-BY + fallback (SVG synthétique, tone).
+• Ajouter ui.overlays pour badges/compteurs/halos et lier à tags, cellNotes ou cellTimers.
+• Aucun HTML/texte additionnel; sortie = JSON seul.
+Procédure:
+1. Classer la demande: pièce, case, timer, zone, victoire, ressource.
+2. Définir moves.pattern/action + effects/mod en respectant captures et règles standard.
+3. Vérifier cohérence spawn/conditions/contraintes, timers et tags.
+4. Générer assets, overlays et tests (≥2, robustes avec assertions finales).
+5. Retourner le JSON final immédiatement.


### PR DESCRIPTION
## Summary
- add a compact meta-prompt guideline for Codex orchestrator usage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1410900188323872fc299aa50fdec