### PR TITLE
Auto-populate compiled ruleset JSON after generation

### DIFF
--- a/src/components/CustomRulesGenerator.tsx
+++ b/src/components/CustomRulesGenerator.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -408,6 +408,13 @@ export function CustomRulesGenerator() {
       setIsGenerating(false);
     }
   };
+
+  useEffect(() => {
+    if (compiledRuleset) {
+      setManualCompiledInput(JSON.stringify(compiledRuleset, null, 2));
+      setManualCompiledError(null);
+    }
+  }, [compiledRuleset]);
 
   const compilationStatus = useMemo(() => {
     if (!compiledHash) {


### PR DESCRIPTION
## Summary
- automatically populate the compiled ruleset textarea with the latest generated CompiledRuleset JSON
- reset manual CompiledRuleset validation errors when a fresh compiled ruleset is produced

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1597d44e083238a2d70b8214aed77