### PR TITLE
Support compiled variant source metadata

### DIFF
--- a/src/components/CustomRulesGenerator.tsx
+++ b/src/components/CustomRulesGenerator.tsx
@@ -180,7 +180,7 @@ export function CustomRulesGenerator() {
       }
 
       const effectiveSource: TablesInsert<'chess_variants'>['source'] =
-        compiledBlock ? ('compiled' as any) : 'generated';
+        compiledBlock ? 'compiled' : 'generated';
 
       const payload: TablesInsert<'chess_variants'> = {
         title: variantName.trim(),
@@ -220,7 +220,7 @@ export function CustomRulesGenerator() {
             rules: generatedRules,
             difficulty,
             prompt: promptText.length > 0 ? promptText : null,
-            source: effectiveSource as any,
+            source: effectiveSource,
             metadata: metadataPayload as TablesUpdate<'chess_variants'>['metadata'],
             rule_id: generatedRuleId,
           };

--- a/src/features/play/routes/Lobby.tsx
+++ b/src/features/play/routes/Lobby.tsx
@@ -108,6 +108,21 @@ type VariantMetadata = {
   ruleSpec?: RuleSpec | null;
 };
 
+const variantSourceDisplayMap: Record<VariantRow['source'], { detail: string; list: string | null }> = {
+  builtin: { detail: "Catalogue", list: null },
+  generated: { detail: "IA", list: "IA" },
+  compiled: { detail: "CompileRuleset JSON", list: "JSON" },
+};
+
+const getVariantSourceDisplay = (
+  source: VariantRow['source'] | null | undefined,
+): { detail: string; list: string | null } => {
+  if (!source) {
+    return variantSourceDisplayMap.builtin;
+  }
+  return variantSourceDisplayMap[source];
+};
+
 const parseVariantMetadata = (metadata: unknown): VariantMetadata => {
   if (!metadata || typeof metadata !== "object") {
     return {};
@@ -291,7 +306,10 @@ export default function Lobby() {
     setVariantRuleErrors(errors);
   }, [remoteVariants]);
   const variantCount = variantRooms.length;
-  const isGeneratedVariant = selectedVariantData?.source === 'generated';
+  const selectedVariantSourceInfo = useMemo(
+    () => getVariantSourceDisplay(selectedVariantData?.source),
+    [selectedVariantData?.source],
+  );
   const isVariantLoading = variantQuery.isLoading && remoteVariants.length === 0;
 
   useEffect(() => {
@@ -830,6 +848,7 @@ export default function Lobby() {
                     <div className="p-2 space-y-2">
                       {variantRooms.map((room) => {
                         const isSelected = selectedVariant === room.id;
+                        const roomSourceInfo = getVariantSourceDisplay(room.source);
                         const createdLabel = room.createdAt
                           ? new Intl.DateTimeFormat("fr-FR", {
                               dateStyle: "medium",
@@ -852,9 +871,9 @@ export default function Lobby() {
                                 {room.title}
                               </span>
                               <div className="flex items-center gap-2">
-                                {room.source === 'generated' && (
+                                {roomSourceInfo.list && (
                                   <span className="inline-flex items-center rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-primary">
-                                    IA
+                                    {roomSourceInfo.list}
                                   </span>
                                 )}
                                 {isSelected && (
@@ -889,7 +908,7 @@ export default function Lobby() {
                         </div>
                         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                           <span className="rounded-full border border-chess-gold/40 bg-background/70 px-3 py-1 font-semibold uppercase tracking-wide text-chess-gold">
-                            Source&nbsp;: {isGeneratedVariant ? 'IA' : 'Catalogue' }
+                            Source&nbsp;: {selectedVariantSourceInfo.detail}
                           </span>
                           <span className="rounded-full border border-border bg-background/70 px-3 py-1 font-medium">
                             {selectedVariantData.ruleId

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -138,7 +138,7 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
-      variant_source: "builtin" | "generated"
+      variant_source: "builtin" | "generated" | "compiled"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -266,7 +266,7 @@ export type CompositeTypes<
 export const Constants = {
   public: {
     Enums: {
-      variant_source: ["builtin", "generated"],
+      variant_source: ["builtin", "generated", "compiled"],
     },
   },
 } as const

--- a/src/services/supabase/types.ts
+++ b/src/services/supabase/types.ts
@@ -444,7 +444,7 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
-      variant_source: 'builtin' | 'generated'
+      variant_source: 'builtin' | 'generated' | 'compiled'
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20251230000000_add_compiled_variant_source_value.sql
+++ b/supabase/migrations/20251230000000_add_compiled_variant_source_value.sql
@@ -1,0 +1,2 @@
+-- Add new value to variant_source enum for compiled rulesets
+alter type public.variant_source add value if not exists 'compiled';


### PR DESCRIPTION
## Summary
- add a migration and update Supabase client typings to include the `compiled` variant source
- persist compiled rulesets without `any` casts when saving or updating custom variants
- surface compiled sources in the lobby with a dedicated badge and label

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e19f79ceb48323b5f867967e78367a