### PR TITLE
Retire l'avertissement obsolète sur les plugins

### DIFF
--- a/src/components/CustomRulesGenerator.tsx
+++ b/src/components/CustomRulesGenerator.tsx
@@ -26,7 +26,6 @@ type GenerationResponse = {
   rules?: string;
   difficulty?: DifficultyLevel;
   warning?: string;
-  pluginWarning?: string;
   ruleId?: string;
   ruleName?: string;
   pluginCode?: string;
@@ -95,7 +94,6 @@ export function CustomRulesGenerator() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedRules, setGeneratedRules] = useState("");
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
-  const [pluginWarning, setPluginWarning] = useState<string | null>(null);
   const [variantName, setVariantName] = useState("");
   const [isSavingVariant, setIsSavingVariant] = useState(false);
   const [lastSavedVariantId, setLastSavedVariantId] = useState<string | null>(null);
@@ -441,10 +439,6 @@ export function CustomRulesGenerator() {
         toast.success("Règles générées avec succès !");
       }
 
-      if (typeof typed.pluginWarning === 'string' && typed.pluginWarning.length > 0) {
-        setPluginWarning(typed.pluginWarning);
-        toast.warning(typed.pluginWarning);
-      }
     } catch (error) {
       console.error('Error generating custom rules:', error);
       const message = error instanceof Error ? error.message : "Erreur lors de la génération des règles";
@@ -585,9 +579,6 @@ export function CustomRulesGenerator() {
                         <li key={index}>⚠️ {warning}</li>
                       ))}
                     </ul>
-                  )}
-                  {pluginWarning && (
-                    <div className="text-xs text-amber-600 dark:text-amber-400">{pluginWarning}</div>
                   )}
                 </div>
               )}

--- a/supabase/functions/generate-custom-rules/core.ts
+++ b/supabase/functions/generate-custom-rules/core.ts
@@ -16,7 +16,6 @@ export interface CustomRulesResponse {
   ruleName: string;
   pluginCode: string;
   warning?: string;
-  pluginWarning?: string;
   compiledRuleset: CompiledRuleset;
   compiledHash: string;
   ruleSpec: RuleSpec;
@@ -58,8 +57,6 @@ const endgameChallenges: Record<DifficultyLevel, string> = {
   advanced:
     "remporter la partie après avoir exécuté une combinaison tactique impliquant au moins trois pièces différentes",
 };
-
-const pluginWarningMessage = "Les plugins JavaScript sont dépréciés. Utilisez le CompiledRuleset JSON.";
 
 const buildFallbackRuleSpec = (
   description: string,
@@ -309,7 +306,6 @@ export async function generateCustomRules(
     ruleName: ruleSpec.meta.name ?? suggestedRuleName,
     pluginCode: "",
     warning,
-    pluginWarning: pluginWarningMessage,
     compiledRuleset,
     compiledHash,
     ruleSpec,


### PR DESCRIPTION
## Summary
- retire le champ `pluginWarning` du générateur afin de ne plus afficher l'alerte obsolète sur les plugins JavaScript
- supprime la constante côté fonction edge qui renvoyait l'avertissement et nettoie l'interface React associée

## Testing
- npm run lint *(échoue : erreurs préexistantes @typescript-eslint/no-explicit-any dans analysis/patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ac35d6f0832397a3f54ba1c80762