### PR TITLE
Fix custom rules parser normalization conflicts

### DIFF
--- a/docs/meta-prompt-compact.md
+++ b/docs/meta-prompt-compact.md
@@ -3,27 +3,29 @@ Rôle: Générateur de variantes d'échecs (prompt → JSON + assets + tests).
 Objectif: À partir d'un prompt naturel, produire UN seul JSON conforme au schéma ci-dessous.
 Schéma obligatoire:
 {
-  "meta": { "name": "...", "description": "..." },
-  "base_version": "chess-base@1.2.0",
-  "patches": [ /* JsonPatch[] */ ],
-  "tests": [ /* 2–5 scripts */ ],
-  "assets": {
-    "sprites": [ { "id": "...", "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback_svg": "<svg/>" } ],
-    "sfx": [ { "id": "...", "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback_tone": { "type": "noiseBurst", "durationMs": 600 } } ],
-    "animation": [ { "id": "...", "type": "spriteSheet", "frames": 12, "fps": 24, "search": { "queries": [], "license": ["CC0","CC-BY"] }, "fallback": { "style": "radial-burst", "colors": ["#fff","#ff6","#f30"] } } ]
+  "meta": {
+    "name": "...",
+    "base": "chess-base@1.0.0",
+    "version": "1.0.0",
+    "description": "...",
+    "priority": 50
   },
-  "ui": { "overlays": [ { "id": "...", "kind": "badgeCounter|marker|halo", "icon": "...", "position": "cellTopRight|center", "dataBinding": "cellNotes|cellTimers" } ] }
+  "patches": [
+    { "op": "extend|replace|remove", "path": "...", "value": { /* JSON */ } }
+  ],
+  "tests": [
+    { "name": "...", "fen": "...", "script": [ { "move": "e2-e4", "by": "pawn" }, { "assert": "..." } ] }
+  ]
 }
 Contraintes:
-• Préserver mouvements légaux, échec/échec-et-mat et checkRules:"classic" sauf ordre contraire explicite.
-• Toujours renseigner patches/tests/assets/ui; mini-DSL patch = op extend|replace|remove + path + value JSON.
-• Actions temporelles avec delayOwnTurns/delayGlobalTurns; déclencheurs explicites trigger:onMove|onCapture|onTimer…
-• Chaque visuel/son/anim possède search.queries + licence CC0/CC-BY + fallback (SVG synthétique, tone).
-• Ajouter ui.overlays pour badges/compteurs/halos et lier à tags, cellNotes ou cellTimers.
+• Préserver mouvements légaux, échec/échec-et-mat et rules.meta.base="chess-base@1.0.0" sauf mention contraire explicite.
+• Toujours fournir au moins un patch pertinent (ou un tableau vide si aucune modification n'est requise) et 2–5 tests ciblés.
+• Utiliser le mini-DSL patch (op extend|replace|remove + path + value JSON).
+• Les scripts de test doivent vérifier mouvements, captures, conditions d'illégalité ou d'état final.
 • Aucun HTML/texte additionnel; sortie = JSON seul.
 Procédure:
 1. Classer la demande: pièce, case, timer, zone, victoire, ressource.
-2. Définir moves.pattern/action + effects/mod en respectant captures et règles standard.
+2. Définir modifications via patches cohérents (ex: "pieces[id=rook].moves").
 3. Vérifier cohérence spawn/conditions/contraintes, timers et tags.
-4. Générer assets, overlays et tests (≥2, robustes avec assertions finales).
+4. Générer 2–5 tests robustes avec assertions finales explicites.
 5. Retourner le JSON final immédiatement.


### PR DESCRIPTION
## Summary
- relax RuleSpec normalization to accept legacy base_version and other fields
- align the meta prompt documentation with the parser expectations to avoid conflicting instructions

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d46c5ce08323be8cf599ffafcb8d