### PR TITLE
Add offline precompiled chess variants

### DIFF
--- a/src/lib/rulesets/types.ts
+++ b/src/lib/rulesets/types.ts
@@ -19,16 +19,6 @@ export interface PieceSpec {
   attributes?: Record<string, unknown>;
 }
 
-export interface EffectSpec {
-  id: string;
-  trigger: "onMove" | "onCapture" | "onHit" | "onTurnStart" | "onTurnEnd";
-  target: "self" | "allyPiece" | "enemyPiece" | "square" | "any";
-  durationTurns?: number;
-  mod: Record<string, unknown>;
-  conditions?: string[];
-  priority?: number;
-}
-
 export interface RulesCore {
   turnOrder: "whiteThenBlack" | "simultaneous";
   checkRules: "classic" | "disabled" | "altX";
@@ -60,10 +50,10 @@ export interface RuleTest {
 }
 
 export interface CompiledRuleset {
-  meta: { name: string; base: string; version: string; description?: string; priority?: number };
+  meta: { name: string; base: string; version: string; description?: string; priority?: number; id?: string };
   board: { size: "8x8" | "10x10"; zones: unknown[] };
   pieces: PieceSpec[];
-  effects: EffectSpec[];
+  effects: Array<Record<string, unknown>>;
   rules: RulesCore;
   tests?: RuleTest[];
 }
@@ -84,6 +74,7 @@ export interface RuleSpec {
     version: string;
     description?: string;
     priority?: number;
+    id?: string;
   };
   patches?: RulePatch[];
   tests?: RuleTest[];

--- a/supabase/functions/_shared/rulesets/types.ts
+++ b/supabase/functions/_shared/rulesets/types.ts
@@ -19,16 +19,6 @@ export interface PieceSpec {
   attributes?: Record<string, unknown>;
 }
 
-export interface EffectSpec {
-  id: string;
-  trigger: "onMove" | "onCapture" | "onHit" | "onTurnStart" | "onTurnEnd";
-  target: "self" | "allyPiece" | "enemyPiece" | "square" | "any";
-  durationTurns?: number;
-  mod: Record<string, unknown>;
-  conditions?: string[];
-  priority?: number;
-}
-
 export interface RulesCore {
   turnOrder: "whiteThenBlack" | "simultaneous";
   checkRules: "classic" | "disabled" | "altX";
@@ -60,10 +50,10 @@ export interface RuleTest {
 }
 
 export interface CompiledRuleset {
-  meta: { name: string; base: string; version: string; description?: string; priority?: number };
+  meta: { name: string; base: string; version: string; description?: string; priority?: number; id?: string };
   board: { size: "8x8" | "10x10"; zones: unknown[] };
   pieces: PieceSpec[];
-  effects: EffectSpec[];
+  effects: Array<Record<string, unknown>>;
   rules: RulesCore;
   tests?: RuleTest[];
 }
@@ -84,6 +74,7 @@ export interface RuleSpec {
     version: string;
     description?: string;
     priority?: number;
+    id?: string;
   };
   patches?: RulePatch[];
   tests?: RuleTest[];


### PR DESCRIPTION
## Summary
- preload the generate-custom-rules endpoint with three new precompiled variants (pion saute, fou mine, dame gel)
- compute deterministic hashes for precompiled rulesets and surface their metadata when matched
- relax shared CompiledRuleset typings so the new payloads (ids, custom effects) are accepted on both server and client

## Testing
- npm run lint *(fails: repo already contains many `@typescript-eslint/no-explicit-any` violations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d907c848832389a08efecdb10a93