### PR TITLE
Sanitise uploaded variant code and fix multiplying pawn rule

### DIFF
--- a/tests/variant-loader-sanitize.test.ts
+++ b/tests/variant-loader-sanitize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getExternalRuleSource,
+  registerExternalRuleFromSource,
+} from "../src/variant-chess-lobby.ts";
+
+describe("registerExternalRuleFromSource sanitisation", () => {
+  test("normalises curly quotes, nbsp and zero-width characters", () => {
+    const raw = "\uFEFF```js\nmodule.exports = {\n\tid: helpers.ruleId || 'pions-sauteurs',\n\tname: “Pions sauteurs”,\n\tdescription: 'Variante test',\n\tonGenerateExtraMoves() { return []; },\n\tonBeforeMoveApply() { return { allow: true }; },\n\tonAfterMoveApply() {},\n\tonTurnStart() {},\n};\n```\u200B";
+
+    const result = registerExternalRuleFromSource("pions-sauteurs", raw);
+
+    expect(result.ok).toBe(true);
+    expect(result.reused).not.toBe(true);
+    const stored = getExternalRuleSource("pions-sauteurs");
+    expect(stored).toBeDefined();
+    expect(stored?.includes("“")).toBe(false);
+    expect(stored?.includes("\u00A0")).toBe(false);
+    expect(stored?.includes("\u200B")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- normalise external rule source loading by stripping smart quotes, zero-width characters and non-breaking spaces before compilation
- ensure the multiplying pawns rule recognises chess.js pawn identifiers so clones are created reliably
- add a regression test covering the sanitisation pipeline for external rules

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e321d9c33483239fffebd1f1201f04