### PR TITLE
feat: wire rule engine variants to lobby

### DIFF
--- a/src/components/ChessRuleEngine.tsx
+++ b/src/components/ChessRuleEngine.tsx
@@ -1,9 +1,19 @@
-import { useState } from "react";
-import { Sparkles, Save, PlayCircle, AlertCircle, CheckCircle } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Sparkles, Save, PlayCircle, AlertCircle, CheckCircle, Loader2, FileCode } from "lucide-react";
 import { supabase } from "@/services/supabase/client";
 import type { RuleSpec, CompiledRuleset } from "@/lib/rulesets/types";
-
-type DifficultyLevel = "beginner" | "intermediate" | "advanced";
+import { toast } from "sonner";
+import type { Tables, TablesInsert, TablesUpdate } from "@/services/supabase/types";
+import {
+  buildSummary,
+  difficultyLabelMap,
+  ensureCompiledHash,
+  sanitisePluginSource,
+  slugify,
+  type DifficultyLevel,
+} from "@/lib/rulesets/generator-helpers";
 
 type CustomRulesResponse = {
   rules?: string;
@@ -28,19 +38,100 @@ type GeneratedRule = {
   pluginWarning?: string;
   ruleSpecJson: string;
   compiledRulesetJson: string | null;
+  ruleSpec: RuleSpec | null;
+  compiledRuleset: CompiledRuleset | null;
+  compiledHash: string | null;
+  pluginCode: string | null;
+  compilerWarnings: string[];
+  rulesText: string;
+  prompt: string;
 };
 
-type SavedRule = GeneratedRule & {
+type SavedRule = {
+  id: string;
+  ruleId: string | null;
+  ruleName: string;
+  difficulty: string | null;
+  description: string;
   createdAt: string;
-  status: "active" | "inactive";
+  ruleSpecJson: string | null;
+  compiledHash: string | null;
+};
+
+type SavedVariantForTest = {
+  id: string;
+  slug: string;
+  ruleId: string;
+  title: string;
+  summary: string;
+  rules: string;
+  difficulty: DifficultyLevel | null;
+  prompt: string | null;
+  compiledRuleset: CompiledRuleset | null;
+  compiledHash: string | null;
+  hasCompiled: boolean;
 };
 
 const ChessRuleEngine = () => {
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [generatedRule, setGeneratedRule] = useState<GeneratedRule | null>(null);
   const [error, setError] = useState("");
-  const [savedRules, setSavedRules] = useState<SavedRule[]>([]);
+  const [lastSavedVariant, setLastSavedVariant] = useState<SavedVariantForTest | null>(null);
+
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const savedVariantsQuery = useQuery({
+    queryKey: ["rule-engine", "saved-variants"],
+    queryFn: async (): Promise<Tables<'chess_variants'>[]> => {
+      const { data, error } = await supabase
+        .from("chess_variants")
+        .select("id, rule_id, title, summary, difficulty, metadata, created_at")
+        .eq("source", "generated")
+        .order("created_at", { ascending: false })
+        .limit(10);
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as Tables<'chess_variants'>[];
+    },
+  });
+
+  const savedRules = useMemo<SavedRule[]>(() => {
+    if (!savedVariantsQuery.data) {
+      return [];
+    }
+
+    return savedVariantsQuery.data.map((row) => {
+      const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+      const ruleSpec =
+        metadata && typeof metadata === "object" && "ruleSpec" in metadata && metadata.ruleSpec
+          ? (metadata.ruleSpec as RuleSpec)
+          : null;
+      const compiledMeta =
+        metadata && typeof metadata === "object" && "compiled" in metadata && metadata.compiled
+          ? (metadata.compiled as Record<string, unknown>)
+          : null;
+
+      const compiledHash =
+        compiledMeta && typeof compiledMeta.hash === "string" ? compiledMeta.hash : null;
+
+      return {
+        id: row.id,
+        ruleId: row.rule_id ?? null,
+        ruleName: row.title,
+        difficulty: row.difficulty ?? null,
+        description: row.summary,
+        createdAt: row.created_at,
+        ruleSpecJson: ruleSpec ? JSON.stringify(ruleSpec, null, 2) : null,
+        compiledHash,
+      } satisfies SavedRule;
+    });
+  }, [savedVariantsQuery.data]);
 
   const generateRule = async () => {
     if (!prompt.trim()) {
@@ -51,6 +142,7 @@ const ChessRuleEngine = () => {
     setLoading(true);
     setError("");
     setGeneratedRule(null);
+    setLastSavedVariant(null);
 
     try {
       const { data, error: functionError } = await supabase.functions.invoke("generate-custom-rules", {
@@ -70,8 +162,23 @@ const ChessRuleEngine = () => {
       }
 
       const response = data as CustomRulesResponse;
-      const ruleSpecJson = response.ruleSpec ? JSON.stringify(response.ruleSpec, null, 2) : "";
-      const compiledRulesetJson = response.compiledRuleset ? JSON.stringify(response.compiledRuleset, null, 2) : null;
+      const ruleSpec = response.ruleSpec ?? null;
+      const { ruleset: ensuredRuleset, hash: ensuredHash } = await ensureCompiledHash(
+        response.compiledRuleset ?? null,
+        response.compiledHash ?? null,
+      );
+
+      const compiledRulesetJson = ensuredRuleset ? JSON.stringify(ensuredRuleset, null, 2) : null;
+      const ruleSpecJson = ruleSpec ? JSON.stringify(ruleSpec, null, 2) : "";
+
+      const textualRules =
+        ensuredRuleset && compiledRulesetJson
+          ? compiledRulesetJson
+          : typeof response.rules === "string" && response.rules.trim().length > 0
+            ? response.rules.trim()
+            : prompt.trim();
+
+      const sanitizedPlugin = sanitisePluginSource(response.pluginCode);
 
       const completedRule: GeneratedRule = {
         ruleId: typeof response.ruleId === "string" && response.ruleId.length > 0 ? response.ruleId : `rule_${Date.now()}`,
@@ -80,21 +187,30 @@ const ChessRuleEngine = () => {
             ? response.ruleName.trim()
             : "Règle personnalisée",
         description:
-          response.ruleSpec?.meta?.description?.trim().length
-            ? response.ruleSpec.meta.description.trim()
-            : prompt.trim(),
+          ruleSpec?.meta?.description?.trim().length
+            ? ruleSpec.meta.description.trim()
+            : textualRules.split("\n").map((line) => line.trim()).find((line) => line.length > 0) ?? prompt.trim(),
         difficulty: response.difficulty ?? "intermediate",
         warning: response.warning,
         pluginWarning: response.pluginWarning,
         ruleSpecJson,
         compiledRulesetJson,
+        ruleSpec,
+        compiledRuleset: ensuredRuleset,
+        compiledHash: ensuredHash ?? null,
+        pluginCode: sanitizedPlugin,
+        compilerWarnings: Array.isArray(response.compilerWarnings) ? response.compilerWarnings : [],
+        rulesText: textualRules,
+        prompt: prompt.trim(),
       };
 
       setGeneratedRule(completedRule);
     } catch (err) {
       console.error("Erreur Lovable:", err);
-      const message = err instanceof Error ? err.message : "Erreur lors de la génération de la règle. Veuillez réessayer.";
+      const message =
+        err instanceof Error ? err.message : "Erreur lors de la génération de la règle. Veuillez réessayer.";
       setError(message);
+      toast.error(message);
     } finally {
       setLoading(false);
     }
@@ -103,29 +219,230 @@ const ChessRuleEngine = () => {
   const saveRule = async () => {
     if (!generatedRule) return;
 
+    setIsSaving(true);
+    setError("");
+
     try {
-      const newRule: SavedRule = {
-        ...generatedRule,
-        createdAt: new Date().toISOString(),
-        status: "active",
+      const { ruleset: ensuredRuleset, hash } = await ensureCompiledHash(
+        generatedRule.compiledRuleset,
+        generatedRule.compiledHash,
+      );
+
+      let compiledBlock:
+        | {
+            hash: string;
+            generatedAt: string;
+            warnings: string[];
+            ruleset: CompiledRuleset;
+          }
+        | null = null;
+
+      if (ensuredRuleset && hash) {
+        compiledBlock = {
+          hash,
+          generatedAt: new Date().toISOString(),
+          warnings: generatedRule.compilerWarnings,
+          ruleset: ensuredRuleset,
+        };
+      }
+
+      const summary = buildSummary(generatedRule.prompt, generatedRule.rulesText, generatedRule.ruleSpec);
+      const baseSlug = slugify(generatedRule.ruleName);
+      const fallbackSlug = baseSlug.length > 0 ? baseSlug : slugify(generatedRule.ruleId) || generatedRule.ruleId;
+      const slug = compiledBlock?.hash ? `${fallbackSlug}-${compiledBlock.hash.slice(0, 6)}` : fallbackSlug;
+
+      const metadataPayload: Record<string, unknown> = { slug };
+
+      if (compiledBlock) {
+        metadataPayload.compiled = compiledBlock;
+        metadataPayload.kind = "automated";
+      }
+
+      if (generatedRule.ruleSpec) {
+        metadataPayload.ruleSpec = generatedRule.ruleSpec;
+      }
+
+      const pluginWarning = generatedRule.pluginWarning ? generatedRule.pluginWarning : undefined;
+
+      if (generatedRule.pluginCode) {
+        metadataPayload.plugin = {
+          source: "external",
+          code: generatedRule.pluginCode,
+          ruleId: generatedRule.ruleId,
+          createdAt: new Date().toISOString(),
+          ...(pluginWarning ? { warning: pluginWarning } : {}),
+        };
+      } else if (compiledBlock || generatedRule.ruleSpec) {
+        metadataPayload.plugin = {
+          source: "schema",
+          ruleId: generatedRule.ruleId,
+          createdAt: new Date().toISOString(),
+          ...(pluginWarning ? { warning: pluginWarning } : {}),
+        };
+      } else if (pluginWarning) {
+        metadataPayload.plugin = {
+          source: "external",
+          ruleId: generatedRule.ruleId,
+          createdAt: new Date().toISOString(),
+          warning: pluginWarning,
+        };
+      }
+
+      const payload: TablesInsert<'chess_variants'> = {
+        title: generatedRule.ruleName,
+        summary,
+        rules: generatedRule.rulesText,
+        difficulty: generatedRule.difficulty,
+        prompt: generatedRule.prompt.length > 0 ? generatedRule.prompt : null,
+        source: "generated",
+        metadata: metadataPayload as TablesInsert<'chess_variants'>['metadata'],
+        rule_id: generatedRule.ruleId,
       };
 
-      setSavedRules((prev) => [...prev, newRule]);
-      console.log("Règle sauvegardée dans le backend:", newRule);
-      alert("Règle sauvegardée avec succès !");
-      setPrompt("");
-      setGeneratedRule(null);
+      const { data, error } = await supabase
+        .from("chess_variants")
+        .insert(payload)
+        .select()
+        .single();
+
+      let variantId = data?.id ?? null;
+      let isUpdate = false;
+
+      if (error) {
+        const conflictText = `${error.message ?? ""} ${error.details ?? ""}`.toLowerCase().trim();
+        const isRuleIdConflict =
+          Boolean(generatedRule.ruleId) &&
+          (conflictText.includes("duplicate key") ||
+            conflictText.includes("chess_variants_rule_id_key") ||
+            error.code === "23505");
+
+        if (isRuleIdConflict && generatedRule.ruleId) {
+          const updatePayload: TablesUpdate<'chess_variants'> = {
+            title: generatedRule.ruleName,
+            summary,
+            rules: generatedRule.rulesText,
+            difficulty: generatedRule.difficulty,
+            prompt: generatedRule.prompt.length > 0 ? generatedRule.prompt : null,
+            source: "generated",
+            metadata: metadataPayload as TablesUpdate<'chess_variants'>['metadata'],
+            rule_id: generatedRule.ruleId,
+          };
+
+          const { data: updatedVariant, error: updateError } = await supabase
+            .from("chess_variants")
+            .update(updatePayload)
+            .eq("rule_id", generatedRule.ruleId)
+            .select()
+            .single();
+
+          if (updateError) throw updateError;
+
+          variantId = updatedVariant?.id ?? null;
+          isUpdate = true;
+        } else {
+          throw error;
+        }
+      }
+
+      if (variantId) {
+        const promptPayload: TablesInsert<'chess_variant_prompts'> = {
+          variant_id: variantId,
+          prompt: generatedRule.prompt.length > 0 ? generatedRule.prompt : summary,
+          difficulty: generatedRule.difficulty,
+          rules: generatedRule.rulesText,
+        };
+
+        const { error: promptError } = await supabase
+          .from("chess_variant_prompts")
+          .insert(promptPayload);
+
+        if (promptError) {
+          console.error("Failed to archive prompt", promptError);
+          toast.warning("Variante enregistrée mais l'historique du prompt n'a pas pu être archivé.");
+        }
+      }
+
+      setLastSavedVariant({
+        id: variantId ?? generatedRule.ruleId,
+        slug: slug.length > 0 ? slug : generatedRule.ruleId,
+        ruleId: generatedRule.ruleId,
+        title: generatedRule.ruleName,
+        summary,
+        rules: generatedRule.rulesText,
+        difficulty: generatedRule.difficulty,
+        prompt: generatedRule.prompt.length > 0 ? generatedRule.prompt : null,
+        compiledRuleset: compiledBlock?.ruleset ?? ensuredRuleset ?? null,
+        compiledHash: compiledBlock?.hash ?? hash ?? null,
+        hasCompiled: Boolean(compiledBlock?.ruleset ?? ensuredRuleset),
+      });
+
+      toast.success(
+        isUpdate ? "Votre variante a été mise à jour dans le lobby !" : "Votre variante a été ajoutée au lobby !",
+      );
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["chess-variants"] }),
+        queryClient.invalidateQueries({ queryKey: ["rule-engine", "saved-variants"] }),
+      ]);
     } catch (err) {
       console.error("Erreur lors de la sauvegarde:", err);
-      setError("Erreur lors de la sauvegarde");
+      const message =
+        err instanceof Error ? err.message : "Impossible d'enregistrer la variante pour le moment.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
     }
   };
 
   const testRule = () => {
-    if (!generatedRule) return;
+    if (!lastSavedVariant) {
+      toast.error("Enregistrez la règle avant de la tester dans l'arène de jeu.");
+      return;
+    }
 
-    console.log("Test de la règle:", generatedRule);
-    alert("Lancement du test de la règle dans l'environnement de jeu...");
+    const params = new URLSearchParams();
+    params.set("variant", lastSavedVariant.slug);
+
+    if (lastSavedVariant.hasCompiled && lastSavedVariant.compiledRuleset) {
+      try {
+        localStorage.setItem(
+          `compiled-ruleset:${lastSavedVariant.slug}`,
+          JSON.stringify(lastSavedVariant.compiledRuleset),
+        );
+        params.set("compiled", "1");
+      } catch (storageError) {
+        console.error("Failed to persist compiled ruleset", storageError);
+      }
+    }
+
+    navigate(`/game?${params.toString()}`, {
+      state: {
+        timeControl: {
+          name: "Blitz 5+0",
+          time: "5+0",
+          minutes: 5,
+          increment: 0,
+          description: "Partie avec variante personnalisée",
+        },
+        eloLevel: { name: "Défi IA", elo: "custom", color: "bg-purple-500" },
+        coachingMode: false,
+        gameMode: "ai",
+        variant: {
+          id: lastSavedVariant.id,
+          title: lastSavedVariant.title,
+          ruleId: lastSavedVariant.ruleId,
+          description: lastSavedVariant.summary,
+          rules: lastSavedVariant.rules,
+          source: "generated" as const,
+          difficulty: lastSavedVariant.difficulty ?? undefined,
+          prompt: lastSavedVariant.prompt ?? undefined,
+          slug: lastSavedVariant.slug,
+          compiledHash: lastSavedVariant.compiledHash,
+          hasCompiled: lastSavedVariant.hasCompiled,
+        },
+      },
+    });
   };
 
   return (
@@ -200,7 +517,9 @@ const ChessRuleEngine = () => {
                   </div>
                   <div>
                     <span className="text-purple-300 font-medium">Difficulté:</span>
-                    <p className="text-white capitalize">{generatedRule.difficulty}</p>
+                    <p className="text-white capitalize">
+                      {difficultyLabelMap[generatedRule.difficulty] ?? generatedRule.difficulty}
+                    </p>
                   </div>
                   {generatedRule.warning && (
                     <div className="text-amber-300 text-sm bg-amber-500/10 border border-amber-300/40 rounded-lg p-3">
@@ -210,6 +529,16 @@ const ChessRuleEngine = () => {
                   {generatedRule.pluginWarning && (
                     <div className="text-amber-300 text-sm bg-amber-500/10 border border-amber-300/40 rounded-lg p-3">
                       {generatedRule.pluginWarning}
+                    </div>
+                  )}
+                  {generatedRule.compilerWarnings.length > 0 && (
+                    <div className="text-amber-200 text-sm bg-amber-500/10 border border-amber-300/40 rounded-lg p-3 space-y-1">
+                      <p className="font-semibold">Avertissements du compilateur :</p>
+                      <ul className="list-disc list-inside space-y-1">
+                        {generatedRule.compilerWarnings.map((warning, index) => (
+                          <li key={index}>{warning}</li>
+                        ))}
+                      </ul>
                     </div>
                   )}
                 </div>
@@ -237,17 +566,31 @@ const ChessRuleEngine = () => {
               </div>
             )}
 
+            {generatedRule.pluginCode && (
+              <div className="bg-slate-900/60 rounded-xl p-4 border border-white/10 mb-6">
+                <h3 className="text-white font-semibold text-lg mb-3 flex items-center gap-2">
+                  <FileCode className="w-4 h-4 text-purple-300" />
+                  Plugin externe
+                </h3>
+                <pre className="bg-black/40 text-purple-200 p-4 rounded-lg overflow-x-auto text-sm">
+                  {generatedRule.pluginCode}
+                </pre>
+              </div>
+            )}
+
             <div className="flex flex-col md:flex-row gap-3">
               <button
                 onClick={saveRule}
-                className="flex-1 bg-green-600 text-white py-3 rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2"
+                disabled={isSaving}
+                className="flex-1 bg-green-600 text-white py-3 rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
               >
-                <Save size={20} />
-                Sauvegarder
+                {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save size={20} />}
+                {isSaving ? "Sauvegarde..." : "Sauvegarder"}
               </button>
               <button
                 onClick={testRule}
-                className="flex-1 bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2"
+                disabled={!lastSavedVariant}
+                className="flex-1 bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
               >
                 <PlayCircle size={20} />
                 Tester
@@ -256,30 +599,53 @@ const ChessRuleEngine = () => {
           </div>
         )}
 
-        {savedRules.length > 0 && (
-          <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 border border-white/20">
-            <h3 className="text-xl font-bold text-white mb-4">
-              Règles Sauvegardées ({savedRules.length})
-            </h3>
-            <div className="space-y-3">
-              {savedRules.map((rule) => (
-                <div key={rule.ruleId} className="bg-white/5 rounded-lg p-4">
-                  <div className="flex items-center justify-between mb-2">
-                    <div>
-                      <p className="text-white font-semibold">{rule.ruleName}</p>
-                      <p className="text-purple-300 text-sm capitalize">{rule.difficulty}</p>
-                    </div>
-                    <span className="text-slate-300 text-sm">{new Date(rule.createdAt).toLocaleString()}</span>
+        <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 border border-white/20 mt-6">
+          <h3 className="text-xl font-bold text-white mb-4 flex items-center justify-between">
+            <span>Règles sauvegardées ({savedRules.length})</span>
+            {savedVariantsQuery.isLoading && <Loader2 className="w-4 h-4 animate-spin text-purple-200" />}
+          </h3>
+
+          {savedVariantsQuery.isError && (
+            <div className="text-red-200 text-sm bg-red-500/10 border border-red-500/40 rounded-lg p-4">
+              Impossible de charger l'historique des variantes enregistrées.
+            </div>
+          )}
+
+          {!savedVariantsQuery.isLoading && savedRules.length === 0 && !savedVariantsQuery.isError && (
+            <p className="text-sm text-purple-200">
+              Aucune variante enregistrée pour le moment. Générez et sauvegardez vos règles pour les retrouver ici.
+            </p>
+          )}
+
+          <div className="space-y-3">
+            {savedRules.map((rule) => (
+              <div key={rule.id} className="bg-white/5 rounded-lg p-4 border border-white/10">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-2">
+                  <div>
+                    <p className="text-white font-semibold">{rule.ruleName}</p>
+                    <p className="text-purple-300 text-sm capitalize">
+                      {rule.difficulty ? rule.difficulty : "Difficulté inconnue"}
+                    </p>
                   </div>
-                  <p className="text-slate-200 text-sm mb-3">{rule.description}</p>
+                  <span className="text-slate-300 text-sm">{new Date(rule.createdAt).toLocaleString()}</span>
+                </div>
+                <p className="text-slate-200 text-sm mb-3">{rule.description}</p>
+                {rule.compiledHash && (
+                  <p className="text-xs text-emerald-300 font-mono mb-2">
+                    Hash&nbsp;: #{rule.compiledHash.slice(0, 12)}
+                  </p>
+                )}
+                {rule.ruleSpecJson ? (
                   <pre className="bg-black/40 text-green-300 p-3 rounded-lg overflow-x-auto text-xs">
                     {rule.ruleSpecJson}
                   </pre>
-                </div>
-              ))}
-            </div>
+                ) : (
+                  <p className="text-xs text-purple-200 italic">RuleSpec non disponible.</p>
+                )}
+              </div>
+            ))}
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/lib/rulesets/generator-helpers.ts
+++ b/src/lib/rulesets/generator-helpers.ts
@@ -1,0 +1,98 @@
+import type { CompiledRuleset, RuleSpec } from "./types";
+import { computeCompiledRulesetHash } from "./hash";
+
+export type DifficultyLevel = "beginner" | "intermediate" | "advanced";
+
+export const difficultyLevels: Array<{ value: DifficultyLevel; label: string }> = [
+  { value: "beginner", label: "Débutant" },
+  { value: "intermediate", label: "Intermédiaire" },
+  { value: "advanced", label: "Avancé" },
+];
+
+export const difficultyLabelMap: Record<DifficultyLevel, string> = {
+  beginner: "Débutant",
+  intermediate: "Intermédiaire",
+  advanced: "Avancé",
+};
+
+export const isDifficultyLevel = (value: string): value is DifficultyLevel =>
+  difficultyLevels.some((option) => option.value === value);
+
+export const slugify = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+
+export const buildDefaultVariantName = (promptValue: string, level: DifficultyLevel) => {
+  const trimmed = promptValue.trim();
+  if (trimmed.length === 0) {
+    return `Variante personnalisée (${difficultyLabelMap[level]})`;
+  }
+  const firstLine = trimmed.split(/\n+/)[0]?.trim() ?? "";
+  const sanitized = firstLine.length > 0 ? firstLine : trimmed;
+  return sanitized.length > 60 ? `${sanitized.slice(0, 57)}…` : sanitized;
+};
+
+export const buildSummary = (promptValue: string, rulesValue: string, spec?: RuleSpec | null) => {
+  if (spec?.meta.description) {
+    return spec.meta.description.length > 240
+      ? `${spec.meta.description.slice(0, 237)}…`
+      : spec.meta.description;
+  }
+  const trimmedPrompt = promptValue.trim();
+  if (trimmedPrompt.length > 0) {
+    return trimmedPrompt.length > 240 ? `${trimmedPrompt.slice(0, 237)}…` : trimmedPrompt;
+  }
+  const firstLine = rulesValue
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return "Variante personnalisée générée avec l’outil IA.";
+  return firstLine.length > 240 ? `${firstLine.slice(0, 237)}…` : firstLine;
+};
+
+const stripCodeFences = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("```") || trimmed.length < 3) {
+    return trimmed;
+  }
+  const fencePattern = /^```[a-zA-Z0-9_-]*\n([\s\S]*?)```$/;
+  const match = trimmed.match(fencePattern);
+  if (match) {
+    return match[1].trim();
+  }
+  const firstBreak = trimmed.indexOf("\n");
+  const closingIndex = trimmed.lastIndexOf("```");
+  if (firstBreak !== -1 && closingIndex > firstBreak) {
+    return trimmed.slice(firstBreak + 1, closingIndex).trim();
+  }
+  return trimmed;
+};
+
+export const sanitisePluginSource = (value: string | null | undefined): string | null => {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const stripped = stripCodeFences(value);
+  const normalised = stripped.replace(/\r\n?/g, "\n");
+  const cleaned = normalised.trim();
+  return cleaned.length > 0 ? cleaned : null;
+};
+
+export async function ensureCompiledHash(
+  ruleset: CompiledRuleset | null,
+  maybeHash?: string | null,
+): Promise<{ ruleset: CompiledRuleset | null; hash: string | null }> {
+  if (!ruleset) {
+    return { ruleset: null, hash: null };
+  }
+  if (typeof maybeHash === "string" && maybeHash.length > 0) {
+    return { ruleset, hash: maybeHash };
+  }
+  const hash = await computeCompiledRulesetHash(ruleset);
+  return { ruleset, hash };
+}


### PR DESCRIPTION
## Summary
- connect the rule engine UI to Supabase so generated variants are stored with compiled metadata and can be launched in-game
- surface recently saved generated variants and plugin diagnostics directly in the rule engine lobby view
- extract reusable rule-generation helpers and share them with the existing custom rules generator

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c98d966c8323b1723fc1e2bf7d7a