### PR TITLE
Sanitize slash-based move patches in custom rule generation

### DIFF
--- a/supabase/functions/generate-custom-rules/core.ts
+++ b/supabase/functions/generate-custom-rules/core.ts
@@ -1184,6 +1184,18 @@ const sanitiseRuleSpecPatches = (
 
     const path = patch.path;
 
+    const invalidSegment = path
+      .split(".")
+      .map((segment) => segment.trim())
+      .find((segment) => segment.includes("/"));
+
+    if (invalidSegment) {
+      logger?.warn?.(
+        `Patch ignoré: le segment "${invalidSegment}" contient un caractère '/' non supporté dans "${path}"`,
+      );
+      return false;
+    }
+
     // Reject unsupported selectors (only [id=...] or [integer] are supported)
     const bracketMatch = path.match(/\[([^\]]+)\]/g);
     if (bracketMatch) {


### PR DESCRIPTION
## Summary
- reject AI-generated rule patches that contain unsupported `/` segments in their paths
- add a regression test to ensure slash-based array append syntax is filtered out

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e3d05efef08323a20e3028df15a87c