### PR TITLE
Add neon cyberpunk styling to chess experience

### DIFF
--- a/src/components/ChessBoard3D.tsx
+++ b/src/components/ChessBoard3D.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useRef, useState, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
-import { Mesh, BoxGeometry, MeshLambertMaterial, Group } from "three";
+import { Mesh, MeshStandardMaterial, Group, MathUtils, DoubleSide } from "three";
 import { Text } from "@react-three/drei";
 import { Chess } from "chess.js";
 import { ChessPiece3D } from "./ChessPiece3D";
@@ -17,10 +17,20 @@ interface ChessBoard3DProps {
 
 // 3D piece heights for visual hierarchy - moved to ChessPiece3D component
 
-function ChessSquare({ 
-  x, 
-  y, 
-  isLight, 
+const NEON_THEME = {
+  lightSquare: "#15042e",
+  darkSquare: "#020617",
+  lightEmissive: "#6d28d9",
+  darkEmissive: "#22d3ee",
+  moveEmissive: "#06b6d4",
+  selectedEmissive: "#f472b6",
+  lastMoveEmissive: "#f97316",
+};
+
+function ChessSquare({
+  x,
+  y,
+  isLight,
   isSelected, 
   isPossibleMove, 
   isLastMove, 
@@ -40,25 +50,82 @@ function ChessSquare({
 }) {
   const squareRef = useRef<Mesh>(null);
   const [hovered, setHovered] = useState(false);
+  const materialRef = useRef<MeshStandardMaterial>(null);
+  const glowRingRef = useRef<Mesh>(null);
+
+  const emissiveColor = useMemo(() => {
+    if (isSelected) {
+      return NEON_THEME.selectedEmissive;
+    }
+    if (isPossibleMove) {
+      return NEON_THEME.moveEmissive;
+    }
+    if (isLastMove) {
+      return NEON_THEME.lastMoveEmissive;
+    }
+    return isLight ? NEON_THEME.lightEmissive : NEON_THEME.darkEmissive;
+  }, [isLight, isLastMove, isPossibleMove, isSelected]);
+
+  const ringColor = useMemo(() => {
+    if (isSelected) {
+      return "#f472b6";
+    }
+    if (isPossibleMove) {
+      return "#22d3ee";
+    }
+    if (isLastMove) {
+      return "#f97316";
+    }
+    return isLight ? "#7c3aed" : "#0ea5e9";
+  }, [isLight, isLastMove, isPossibleMove, isSelected]);
 
   useFrame((state) => {
     if (squareRef.current) {
-      // Subtle animation for selected/highlighted squares
+      const basePulse = Math.sin(state.clock.elapsedTime * 2) * 0.02;
       if (isSelected) {
-        squareRef.current.position.y = 0.05 + Math.sin(state.clock.elapsedTime * 3) * 0.02;
+        squareRef.current.position.y = 0.08 + basePulse;
       } else if (isPossibleMove) {
-        squareRef.current.position.y = 0.02 + Math.sin(state.clock.elapsedTime * 2) * 0.01;
+        squareRef.current.position.y = 0.04 + basePulse * 0.6;
+      } else if (hovered) {
+        squareRef.current.position.y = 0.02 + basePulse * 0.3;
       } else {
         squareRef.current.position.y = 0;
       }
     }
+
+    if (materialRef.current) {
+      const basePulse = 0.25 + Math.sin(state.clock.elapsedTime * 1.8) * 0.05;
+      let targetIntensity = hovered ? 0.4 : basePulse;
+
+      if (isPossibleMove) {
+        targetIntensity = 0.85 + Math.sin(state.clock.elapsedTime * 3) * 0.1;
+      }
+
+      if (isLastMove) {
+        targetIntensity = 0.7;
+      }
+
+      if (isSelected) {
+        targetIntensity = 1.25 + Math.sin(state.clock.elapsedTime * 4) * 0.1;
+      }
+
+      materialRef.current.emissiveIntensity = MathUtils.lerp(
+        materialRef.current.emissiveIntensity ?? targetIntensity,
+        targetIntensity,
+        0.12
+      );
+    }
+
+    if (glowRingRef.current) {
+      const baseScale = isSelected ? 1.15 : isPossibleMove ? 1.08 : 1.02;
+      const pulse = Math.sin(state.clock.elapsedTime * 4) * 0.05;
+      glowRingRef.current.scale.setScalar(baseScale + pulse);
+      glowRingRef.current.visible = isSelected || isPossibleMove || isLastMove;
+    }
   });
 
-  const squareColor = isLight 
-    ? (isSelected ? '#ffd700' : isLastMove ? '#ffeb3b' : isPossibleMove ? '#81c784' : '#f5f5dc')
-    : (isSelected ? '#b8860b' : isLastMove ? '#fbc02d' : isPossibleMove ? '#66bb6a' : '#8b4513');
-
-  const pieceColor = piece && piece === piece.toUpperCase() ? '#f8f8f8' : '#2c2c2c';
+  const squareColor = isLight ? NEON_THEME.lightSquare : NEON_THEME.darkSquare;
+  const pieceColor = piece && piece === piece.toUpperCase() ? "#f8f8f8" : "#2c2c2c";
 
   return (
     <group position={[x - 3.5, 0, y - 3.5]}>
@@ -71,14 +138,40 @@ function ChessSquare({
         scale={hovered ? 1.05 : 1}
       >
         <boxGeometry args={[0.9, 0.1, 0.9]} />
-        <meshLambertMaterial color={squareColor} />
+        <meshStandardMaterial
+          ref={materialRef}
+          color={squareColor}
+          emissive={emissiveColor}
+          emissiveIntensity={isSelected ? 1.2 : 0.35}
+          metalness={0.6}
+          roughness={0.35}
+        />
+      </mesh>
+
+      {/* Neon glow ring */}
+      <mesh
+        ref={glowRingRef}
+        position={[0, 0.08, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        visible={isSelected || isPossibleMove || isLastMove}
+      >
+        <ringGeometry args={[0.28, 0.44, 48]} />
+        <meshBasicMaterial color={ringColor} transparent opacity={0.55} side={DoubleSide} />
       </mesh>
 
       {/* Possible move indicator */}
       {isPossibleMove && !piece && (
         <mesh position={[0, 0.15, 0]}>
           <sphereGeometry args={[0.15, 8, 6]} />
-          <meshLambertMaterial color="#4caf50" transparent opacity={0.7} />
+          <meshStandardMaterial
+            color="#0ea5e9"
+            emissive="#22d3ee"
+            emissiveIntensity={1.4}
+            metalness={0.8}
+            roughness={0.1}
+            transparent
+            opacity={0.85}
+          />
         </mesh>
       )}
 
@@ -95,21 +188,21 @@ function ChessSquare({
       {/* Square label */}
       {x === 0 && (
         <Text
-          position={[-0.6, 0.2, 0]}
+          position={[-0.6, 0.22, 0]}
           fontSize={0.2}
-          color="#666"
+          color="#a855f7"
           anchorX="center"
           anchorY="middle"
           rotation={[-Math.PI / 2, 0, 0]}
-        >
+          >
           {8 - y}
         </Text>
       )}
       {y === 7 && (
         <Text
-          position={[0, 0.2, 0.6]}
+          position={[0, 0.22, 0.6]}
           fontSize={0.2}
-          color="#666"
+          color="#22d3ee"
           anchorX="center"
           anchorY="middle"
           rotation={[-Math.PI / 2, 0, 0]}
@@ -170,16 +263,43 @@ export const ChessBoard3D = forwardRef<Group, ChessBoard3DProps>(
         {!hideBoard && (
           <>
             {/* Board base */}
-            <mesh position={[0, -0.2, 0]}>
-              <boxGeometry args={[8.5, 0.3, 8.5]} />
-              <meshLambertMaterial color="#8b4513" />
+            <mesh position={[0, -0.35, 0]}>
+              <boxGeometry args={[9.5, 0.5, 9.5]} />
+              <meshStandardMaterial
+                color="#020617"
+                metalness={0.8}
+                roughness={0.2}
+                emissive="#1e1b4b"
+                emissiveIntensity={0.45}
+              />
             </mesh>
 
-            {/* Border */}
+            {/* Neon frame */}
             <mesh position={[0, -0.1, 0]}>
-              <boxGeometry args={[9, 0.1, 9]} />
-              <meshLambertMaterial color="#654321" />
+              <boxGeometry args={[10, 0.12, 10]} />
+              <meshStandardMaterial
+                color="#0b1120"
+                metalness={0.95}
+                roughness={0.15}
+                emissive="#22d3ee"
+                emissiveIntensity={0.9}
+              />
             </mesh>
+
+            {/* Floating border glow */}
+            <mesh position={[0, 0.25, 0]}>
+              <boxGeometry args={[8.9, 0.02, 8.9]} />
+              <meshStandardMaterial
+                color="#111827"
+                metalness={0.6}
+                roughness={0.3}
+                emissive="#7c3aed"
+                emissiveIntensity={0.6}
+              />
+            </mesh>
+
+            <pointLight position={[4, 3, 4]} intensity={0.55} color="#22d3ee" distance={10} />
+            <pointLight position={[-4, 3, -4]} intensity={0.5} color="#f472b6" distance={10} />
           </>
         )}
 

--- a/src/components/ChessPiece3D.tsx
+++ b/src/components/ChessPiece3D.tsx
@@ -1,7 +1,13 @@
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Text } from '@react-three/drei';
-import { Mesh, Group, BoxGeometry, CylinderGeometry, SphereGeometry, ConeGeometry, TorusGeometry } from 'three';
+import {
+  Mesh,
+  Group,
+  MeshStandardMaterial,
+  MeshBasicMaterial,
+  MathUtils,
+  DoubleSide,
+} from 'three';
 
 interface ChessPiece3DProps {
   piece: string;
@@ -13,14 +19,58 @@ interface ChessPiece3DProps {
 // 3D piece heights for visual hierarchy
 const PIECE_HEIGHTS = {
   'K': 1.4, 'Q': 1.3, 'R': 1.0, 'B': 1.1, 'N': 1.1, 'P': 0.7,
-  'k': 1.4, 'q': 1.3, 'r': 1.0, 'b': 1.1, 'n': 1.1, 'p': 0.7
+  'k': 1.4, 'q': 1.3, 'r': 1.0, 'b': 1.1, 'n': 1.1, 'p': 0.7,
 };
+
+const WHITE_NEON = {
+  base: '#e0f2fe',
+  accent: '#c4b5fd',
+  emissive: '#7dd3fc',
+  glow: '#60a5fa',
+  ring: '#38bdf8',
+  selection: '#22d3ee',
+} as const;
+
+const BLACK_NEON = {
+  base: '#0f172a',
+  accent: '#f472b6',
+  emissive: '#f472b6',
+  glow: '#be123c',
+  ring: '#fb7185',
+  selection: '#f43f5e',
+} as const;
 
 export function ChessPiece3D({ piece, position, isSelected, onClick }: ChessPiece3DProps) {
   const groupRef = useRef<Group>(null);
+  const glowRingRef = useRef<Mesh>(null);
+  const glowMaterialRef = useRef<MeshBasicMaterial>(null);
   const isWhite = piece === piece.toUpperCase();
   const pieceType = piece.toLowerCase();
-  
+
+  const palette = useMemo(() => (isWhite ? WHITE_NEON : BLACK_NEON), [isWhite]);
+
+  const baseMaterialProps = useMemo(
+    () => ({
+      color: palette.base,
+      metalness: 0.85,
+      roughness: 0.25,
+      emissive: palette.emissive,
+      emissiveIntensity: 0.6,
+    }),
+    [palette]
+  );
+
+  const accentMaterialProps = useMemo(
+    () => ({
+      color: palette.accent,
+      metalness: 0.9,
+      roughness: 0.15,
+      emissive: palette.glow,
+      emissiveIntensity: 0.8,
+    }),
+    [palette]
+  );
+
   useFrame((state) => {
     if (groupRef.current) {
       if (isSelected) {
@@ -30,11 +80,43 @@ export function ChessPiece3D({ piece, position, isSelected, onClick }: ChessPiec
         groupRef.current.position.y = PIECE_HEIGHTS[piece];
         groupRef.current.rotation.y = Math.sin(state.clock.elapsedTime * 0.5) * 0.1;
       }
+
+      groupRef.current.traverse((child) => {
+        if ((child as Mesh).isMesh) {
+          const mesh = child as Mesh;
+          const material = mesh.material;
+
+          const updateMaterial = (mat: MeshStandardMaterial) => {
+            if (!mat.isMeshStandardMaterial) return;
+            const base = isWhite ? 0.55 : 0.65;
+            const pulse = Math.sin(state.clock.elapsedTime * 2 + (isWhite ? 0 : Math.PI / 2)) * 0.12;
+            const selectedBoost = isSelected ? 0.9 : 0;
+            mat.emissiveIntensity = MathUtils.lerp(
+              mat.emissiveIntensity ?? base,
+              base + pulse + selectedBoost,
+              0.08
+            );
+          };
+
+          if (Array.isArray(material)) {
+            material.forEach((mat) => updateMaterial(mat as MeshStandardMaterial));
+          } else if ((material as MeshStandardMaterial)?.isMeshStandardMaterial) {
+            updateMaterial(material as MeshStandardMaterial);
+          }
+        }
+      });
+    }
+
+    if (glowRingRef.current) {
+      const scale = 1 + Math.sin(state.clock.elapsedTime * 3) * 0.05;
+      glowRingRef.current.scale.setScalar(scale);
+    }
+
+    if (glowMaterialRef.current) {
+      const baseOpacity = isSelected ? 0.75 : 0.45;
+      glowMaterialRef.current.opacity = baseOpacity + Math.sin(state.clock.elapsedTime * 2.5) * 0.1;
     }
   });
-
-  const baseColor = isWhite ? '#f8f8f8' : '#2c2c2c';
-  const accentColor = isWhite ? '#e8e8e8' : '#1c1c1c';
 
   const renderPieceGeometry = () => {
     switch (pieceType) {
@@ -44,188 +126,188 @@ export function ChessPiece3D({ piece, position, isSelected, onClick }: ChessPiec
             {/* Base */}
             <mesh position={[0, -0.6, 0]}>
               <cylinderGeometry args={[0.4, 0.5, 0.3, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Body */}
             <mesh position={[0, -0.2, 0]}>
               <cylinderGeometry args={[0.35, 0.4, 0.6, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Head */}
             <mesh position={[0, 0.2, 0]}>
               <sphereGeometry args={[0.25, 12, 8]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             {/* Crown cross */}
             <mesh position={[0, 0.5, 0]}>
               <boxGeometry args={[0.05, 0.3, 0.05]} />
-              <meshLambertMaterial color={accentColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             <mesh position={[0, 0.4, 0]}>
               <boxGeometry args={[0.3, 0.05, 0.05]} />
-              <meshLambertMaterial color={accentColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
           </group>
         );
-      
+
       case 'q': // Queen
         return (
           <group>
             {/* Base */}
             <mesh position={[0, -0.6, 0]}>
               <cylinderGeometry args={[0.4, 0.45, 0.3, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Body */}
             <mesh position={[0, -0.15, 0]}>
               <cylinderGeometry args={[0.3, 0.4, 0.7, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Crown */}
             <mesh position={[0, 0.4, 0]}>
               <cylinderGeometry args={[0.15, 0.3, 0.3, 8]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             {/* Crown spikes */}
             {[0, 1, 2, 3, 4, 5, 6, 7].map(i => (
-              <mesh 
-                key={i} 
+              <mesh
+                key={i}
                 position={[
-                  Math.cos(i * Math.PI / 4) * 0.25, 
-                  0.6, 
+                  Math.cos(i * Math.PI / 4) * 0.25,
+                  0.6,
                   Math.sin(i * Math.PI / 4) * 0.25
                 ]}
               >
                 <coneGeometry args={[0.03, 0.15, 4]} />
-                <meshLambertMaterial color={accentColor} />
+                <meshStandardMaterial {...accentMaterialProps} />
               </mesh>
             ))}
           </group>
         );
-      
+
       case 'r': // Rook
         return (
           <group>
             {/* Base */}
             <mesh position={[0, -0.4, 0]}>
               <cylinderGeometry args={[0.35, 0.4, 0.3, 8]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Tower */}
             <mesh position={[0, 0, 0]}>
               <boxGeometry args={[0.6, 0.8, 0.6]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Battlements */}
             <mesh position={[0.15, 0.5, 0.15]}>
               <boxGeometry args={[0.1, 0.2, 0.1]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             <mesh position={[-0.15, 0.5, 0.15]}>
               <boxGeometry args={[0.1, 0.2, 0.1]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             <mesh position={[0.15, 0.5, -0.15]}>
               <boxGeometry args={[0.1, 0.2, 0.1]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             <mesh position={[-0.15, 0.5, -0.15]}>
               <boxGeometry args={[0.1, 0.2, 0.1]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
           </group>
         );
-      
+
       case 'b': // Bishop
         return (
           <group>
             {/* Base */}
             <mesh position={[0, -0.5, 0]}>
               <cylinderGeometry args={[0.3, 0.35, 0.3, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Body */}
             <mesh position={[0, -0.1, 0]}>
               <cylinderGeometry args={[0.15, 0.3, 0.6, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Head */}
             <mesh position={[0, 0.3, 0]}>
               <sphereGeometry args={[0.2, 12, 8]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             {/* Mitre */}
             <mesh position={[0, 0.5, 0]} rotation={[0, 0, Math.PI / 6]}>
               <coneGeometry args={[0.1, 0.25, 6]} />
-              <meshLambertMaterial color={accentColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
           </group>
         );
-      
+
       case 'n': // Knight
         return (
           <group>
             {/* Base */}
             <mesh position={[0, -0.5, 0]}>
               <cylinderGeometry args={[0.3, 0.35, 0.3, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Horse body */}
             <mesh position={[0, -0.1, 0.1]}>
               <boxGeometry args={[0.4, 0.6, 0.5]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Horse head */}
             <mesh position={[0, 0.2, -0.2]} rotation={[-0.3, 0, 0]}>
               <boxGeometry args={[0.3, 0.4, 0.6]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             {/* Ears */}
             <mesh position={[-0.1, 0.45, -0.4]}>
               <coneGeometry args={[0.05, 0.15, 4]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
             <mesh position={[0.1, 0.45, -0.4]}>
               <coneGeometry args={[0.05, 0.15, 4]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
           </group>
         );
-      
+
       case 'p': // Pawn
         return (
           <group>
             {/* Base */}
             <mesh position={[0, -0.3, 0]}>
               <cylinderGeometry args={[0.2, 0.25, 0.2, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Body */}
             <mesh position={[0, 0, 0]}>
               <cylinderGeometry args={[0.15, 0.2, 0.4, 12]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...baseMaterialProps} />
             </mesh>
             {/* Head */}
             <mesh position={[0, 0.25, 0]}>
               <sphereGeometry args={[0.15, 12, 8]} />
-              <meshLambertMaterial color={baseColor} />
+              <meshStandardMaterial {...accentMaterialProps} />
             </mesh>
           </group>
         );
-      
+
       default:
         return (
           <mesh>
             <sphereGeometry args={[0.2, 8, 6]} />
-            <meshLambertMaterial color={baseColor} />
+            <meshStandardMaterial {...baseMaterialProps} />
           </mesh>
         );
     }
   };
 
   return (
-    <group 
-      ref={groupRef} 
+    <group
+      ref={groupRef}
       position={position}
       onClick={onClick}
       onPointerOver={(e) => {
@@ -237,26 +319,44 @@ export function ChessPiece3D({ piece, position, isSelected, onClick }: ChessPiec
       }}
     >
       {renderPieceGeometry()}
-      
+
+      {/* Ambient neon aura */}
+      <mesh
+        ref={glowRingRef}
+        position={[0, -0.68, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <ringGeometry args={[0.2, 0.55, 64]} />
+        <meshBasicMaterial
+          ref={glowMaterialRef}
+          color={palette.ring}
+          transparent
+          opacity={0.45}
+          side={DoubleSide}
+        />
+      </mesh>
+
       {/* Selection glow effect */}
       {isSelected && (
         <mesh position={[0, -0.7, 0]}>
-          <cylinderGeometry args={[0.6, 0.6, 0.05, 16]} />
-          <meshLambertMaterial 
-            color="#ffd700" 
-            transparent 
-            opacity={0.6}
-            emissive="#ffd700"
-            emissiveIntensity={0.3}
+          <cylinderGeometry args={[0.65, 0.65, 0.08, 24]} />
+          <meshStandardMaterial
+            color={palette.selection}
+            emissive={palette.selection}
+            emissiveIntensity={1.5}
+            metalness={0.4}
+            roughness={0.2}
+            transparent
+            opacity={0.85}
           />
         </mesh>
       )}
-      
+
       {/* Subtle ambient lighting for the piece */}
-      <pointLight 
-        position={[0, 1, 0]} 
-        intensity={0.3} 
-        color={isWhite ? "#ffffff" : "#cccccc"} 
+      <pointLight
+        position={[0, 1, 0]}
+        intensity={0.45}
+        color={palette.ring}
         distance={2}
       />
     </group>

--- a/src/features/play/BoardWithBot.tsx
+++ b/src/features/play/BoardWithBot.tsx
@@ -284,7 +284,7 @@ export function BoardWithBot({ bot, orientation = "white", className }: BoardWit
 
   return (
     <div className={cn("grid gap-6 lg:grid-cols-[2fr,1fr]", className)}>
-      <Card className="overflow-hidden">
+      <Card className="neon-card overflow-hidden bg-transparent">
         <CardHeader className="flex flex-col gap-3">
           <div className="flex flex-wrap items-center gap-3">
             <CardTitle className="text-2xl font-semibold">
@@ -307,7 +307,7 @@ export function BoardWithBot({ bot, orientation = "white", className }: BoardWit
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="relative aspect-square w-full">
+          <div className="relative mx-auto aspect-square w-full max-w-mobile-board min-h-mobile-board sm:min-h-0">
             <Canvas shadows>
               <ambientLight intensity={0.6} />
               <directionalLight position={[5, 10, 5]} intensity={0.9} castShadow />

--- a/src/features/play/routes/ChessGame.tsx
+++ b/src/features/play/routes/ChessGame.tsx
@@ -759,21 +759,25 @@ export default function ChessGame() {
   }[coachLanguage];
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-6">
+    <div className="min-h-screen neon-grid text-slate-100">
+      <div className="container mx-auto max-w-6xl px-4 py-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
-          <Button variant="outline" onClick={() => navigate("/")} className="hover-lift">
+          <Button
+            variant="outline"
+            onClick={() => navigate("/")}
+            className="hover-lift border-cyan-500/60 bg-slate-950/60 text-slate-100 backdrop-blur"
+          >
             <ArrowLeft className="w-4 h-4 mr-2" />
             Retour
           </Button>
-          
+
           <div className="text-center">
-            <h1 className="text-2xl font-bold text-chess-gold">
+            <h1 className="text-2xl font-bold text-cyan-200 drop-shadow-[0_0_12px_rgba(34,211,238,0.45)]">
               {gameState.timeControl?.time} • {gameMode === 'local' ? '2 joueurs' : gameState.coachingMode ? "Mode Coaching" : gameState.eloLevel?.name}
               {activeVariant && ` • ${activeVariant.title}`}
             </h1>
-            <div className="flex flex-wrap items-center gap-2 justify-center mt-1">
+            <div className="flex flex-wrap items-center gap-2 justify-center mt-2 text-slate-300">
               <Badge variant={gameStatus === 'playing' ? "default" : "secondary"}>
                 {gameStatus === 'playing' ? 'En cours' :
                  gameStatus === 'checkmate' ? 'Échec et mat' :
@@ -808,17 +812,29 @@ export default function ChessGame() {
 
           <div className="flex gap-2">
             {isVariantReady && activeVariant && (
-              <Button variant="outline" onClick={handleSpecialMove} className="hover-lift">
+              <Button
+                variant="outline"
+                onClick={handleSpecialMove}
+                className="hover-lift border-fuchsia-500/70 bg-slate-950/60 text-fuchsia-200 backdrop-blur"
+              >
                 <Sparkles className="w-4 h-4 mr-2" />
                 Attaque spéciale
               </Button>
             )}
-            <Button variant="outline" onClick={handleNewGame} className="hover-lift">
+            <Button
+              variant="outline"
+              onClick={handleNewGame}
+              className="hover-lift border-cyan-500/60 bg-slate-950/60 text-cyan-200 backdrop-blur"
+            >
               <RotateCcw className="w-4 h-4 mr-2" />
               Nouvelle partie
             </Button>
             {gameStatus === 'playing' && (
-              <Button variant="destructive" onClick={handleResign} className="hover-lift">
+              <Button
+                variant="destructive"
+                onClick={handleResign}
+                className="hover-lift bg-rose-500/80 text-white shadow-[0_0_25px_rgba(244,63,94,0.55)]"
+              >
                 <Flag className="w-4 h-4 mr-2" />
                 Abandonner
               </Button>
@@ -835,8 +851,8 @@ export default function ChessGame() {
               isWhiteTurn={isWhiteTurn}
               gameStatus={gameStatus}
             />
-            
-            <Card className="p-4 gradient-card border-chess/60">
+
+            <Card className="neon-card p-4 border-cyan-500/30 bg-transparent">
               <div className="flex items-center justify-between gap-4">
                 <div>
                   <p className="text-sm font-semibold">{coachConfig.coachTitle}</p>
@@ -879,9 +895,9 @@ export default function ChessGame() {
           </div>
 
           {/* 3D Chess Board */}
-          <div className="lg:col-span-3">
-            <Card className="p-4 gradient-card border-chess">
-              <div className="aspect-square w-full max-w-2xl mx-auto">
+          <div className="lg:col-span-3 flex flex-col items-center">
+            <Card className="neon-card w-full p-4 border-cyan-500/40 bg-transparent">
+              <div className="relative mx-auto aspect-square w-full max-w-mobile-board min-h-mobile-board sm:min-h-0 sm:max-w-3xl">
                 <Canvas shadows>
                   <AnimatedCamera />
                   <Environment preset="sunset" background />

--- a/src/features/puzzles/PuzzleTrainer.tsx
+++ b/src/features/puzzles/PuzzleTrainer.tsx
@@ -430,7 +430,7 @@ export function PuzzleTrainer({ className }: PuzzleTrainerProps) {
   const canShowBoard = Boolean(currentPuzzle) && !isFetching;
 
   return (
-    <Card className={cn("flex h-full flex-col", className)}>
+    <Card className={cn("neon-card flex h-full flex-col bg-transparent", className)}>
       <CardHeader className="gap-2">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -486,7 +486,7 @@ export function PuzzleTrainer({ className }: PuzzleTrainerProps) {
           </Alert>
         ) : (
           <div className="space-y-4">
-            <div className="relative aspect-square w-full">
+            <div className="relative mx-auto aspect-square w-full max-w-mobile-board min-h-mobile-board sm:min-h-0">
               <Canvas shadows>
                 <ambientLight intensity={0.6} />
                 <directionalLight position={[5, 10, 5]} intensity={0.9} castShadow />

--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,48 @@ All colors MUST be HSL.
     background: var(--gradient-card);
   }
 
+  .neon-card {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1.5rem;
+    border: 1px solid rgba(34, 211, 238, 0.35);
+    background: linear-gradient(145deg, rgba(2, 6, 23, 0.75), rgba(30, 27, 75, 0.7));
+    box-shadow:
+      0 0 35px rgba(34, 211, 238, 0.18),
+      0 0 65px rgba(168, 85, 247, 0.25);
+    backdrop-filter: blur(24px);
+  }
+
+  .neon-card::before {
+    content: "";
+    position: absolute;
+    inset: -120%;
+    background: conic-gradient(from 90deg, rgba(34, 211, 238, 0.45), rgba(236, 72, 153, 0.25), rgba(129, 140, 248, 0.45), rgba(34, 211, 238, 0.45));
+    animation: neonOrbit 18s linear infinite;
+    opacity: 0.35;
+  }
+
+  .neon-card::after {
+    content: "";
+    position: absolute;
+    inset: 2px;
+    border-radius: 1.4rem;
+    background: radial-gradient(circle at top, rgba(34, 211, 238, 0.12), transparent 65%), rgba(15, 23, 42, 0.92);
+    z-index: 1;
+  }
+
+  .neon-card > * {
+    position: relative;
+    z-index: 5;
+  }
+
+  .neon-grid {
+    background:
+      radial-gradient(circle at top, rgba(88, 28, 135, 0.45), transparent 60%),
+      radial-gradient(circle at bottom, rgba(14, 165, 233, 0.28), transparent 60%),
+      linear-gradient(135deg, rgba(2, 6, 23, 0.98), rgba(8, 0, 24, 0.96));
+  }
+
   .text-chess-gold {
     color: hsl(var(--chess-gold));
   }
@@ -173,5 +215,40 @@ All colors MUST be HSL.
 
   .border-chess {
     border-color: hsl(var(--board-highlight));
+  }
+}
+
+@layer utilities {
+  .max-w-mobile-board {
+    max-width: min(90vw, 42rem);
+  }
+
+  .min-h-mobile-board {
+    min-height: min(75vh, 90vw);
+  }
+
+  .animate-neon-pulse {
+    animation: neonPulse 6s ease-in-out infinite;
+  }
+}
+
+@keyframes neonOrbit {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes neonPulse {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 25px rgba(34, 211, 238, 0.35));
+    opacity: 0.85;
+  }
+  50% {
+    filter: drop-shadow(0 0 45px rgba(168, 85, 247, 0.45));
+    opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the 3D chessboard and pieces with neon cyberpunk materials, emissive pulses, and glow accents
- refresh the game, bot, and puzzle layouts with neon Tailwind cards and mobile-focused board centering
- add reusable Tailwind utilities for neon surfaces and responsive board sizing

## Testing
- npm run lint *(fails: existing repository lint errors about @typescript-eslint/no-explicit-any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e43733c3148323b39ff6366266b8b3